### PR TITLE
feat: 사운드매니저 작동 방식 수정

### DIFF
--- a/Assets/Player/Prefab/AudioSource.prefab
+++ b/Assets/Player/Prefab/AudioSource.prefab
@@ -1,0 +1,131 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1637483021747288487
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8483426853859618504}
+  - component: {fileID: 2071045233083232603}
+  m_Layer: 0
+  m_Name: AudioSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8483426853859618504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1637483021747288487}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &2071045233083232603
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1637483021747288487}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Player/Prefab/AudioSource.prefab.meta
+++ b/Assets/Player/Prefab/AudioSource.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7eb805ac68055f34dba584fe79bf2be8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/Prefab/SoundManager.prefab
+++ b/Assets/Player/Prefab/SoundManager.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 162642701154191956}
   - component: {fileID: 5945280868669061270}
-  - component: {fileID: 6244687107994152189}
   m_Layer: 0
   m_Name: SoundManager
   m_TagString: Untagged
@@ -27,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 8056616088733125454}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.00334, y: 0.99998, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -45,101 +44,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcd51381be198374cb1aed83467674c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SoundManager
-  playerSource: {fileID: 6244687107994152189}
---- !u!82 &6244687107994152189
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8056616088733125454}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_Resource: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
+  playerSource: {fileID: 0}

--- a/Assets/Player/Scripts/PlayerStatController.cs
+++ b/Assets/Player/Scripts/PlayerStatController.cs
@@ -83,7 +83,6 @@ public class PlayerStatController : MonoBehaviour
     // 플레이어의 hp를 치료하는 효과는 다른 함수로 구현하도록 한다.
     public void GetDamage(int damage)
     {
-        Debug.Log($"animator: {animator.name}, has controller: {animator.runtimeAnimatorController != null}");
         bool isDead = animator.GetBool("isDead");
 
         // 플레이어가 이미 죽은 경우 함수 미적용

--- a/Assets/Scenes/PlayerScene.unity
+++ b/Assets/Scenes/PlayerScene.unity
@@ -119,6 +119,73 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &341693910
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 217228043390551020}
+    m_Modifications:
+    - target: {fileID: 1637483021747288487, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_Name
+      value: playerSound
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.00334
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+--- !u!82 &341693911 stripped
+AudioSource:
+  m_CorrespondingSourceObject: {fileID: 2071045233083232603, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+  m_PrefabInstance: {fileID: 341693910}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &341693912 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8483426853859618504, guid: 7eb805ac68055f34dba584fe79bf2be8, type: 3}
+  m_PrefabInstance: {fileID: 341693910}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &594040551
 GameObject:
   m_ObjectHideFlags: 0
@@ -384,11 +451,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.00334
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.99998
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
       propertyPath: m_LocalPosition.z
@@ -422,15 +489,27 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5945280868669061270, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: playerSource
+      value: 
+      objectReference: {fileID: 341693911}
     - target: {fileID: 8056616088733125454, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
       propertyPath: m_Name
       value: SoundManager
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 341693912}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+--- !u!4 &217228043390551020 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+  m_PrefabInstance: {fileID: 217228043390551019}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## **제목: feat: SoundManager 작동 방식 리팩터링**

## **개요**

이 변경 내역은 `SoundManager`의 작동 방식을 수정하여 '다양한 사운드 소스의 출력을 관리'하는 것의 편의성을 늘리기 위함임.

## **문제점**

기존에는 `SoundManager` 프리팹에 `AudioSource` 컴포넌트를 추가하는 방식이었음.
단일 사운드 소스 출력에는 충분했지만 다양한 종류의 사운드를 출력해야 하는 경우 여러 개의 `AudioSource` 컴포넌트를 추가해야 했고, 그 점이 매우 불편해질지도 모르겠다는 생각이 들었음.

## **변경 내용**

1.  **`AudioSource` 프리팹 분리**:
    - 독립적으로 재사용 가능한 `AudioSource.prefab`을 생성함
    - 앞으로 새로운 오디오 소스를 사용하고 싶은 경우, SoundManager 프리팹에 해당 프리팹을 넣는 식으로 구현해야 함
        - 새롭게 하위 게임오브젝트로 넣은 AudioSource 프리팹의 이름을 용도에 맞게 수정하는 것을 매우 권장함
    - 이에 따라 기존 `SoundManager` 게임 오브젝트에서 `AudioSource` 컴포넌트를 제거했음
        - 그러나 인스펙터에서 할당해야 하는 것은 여전히 `AudioSource` 컴포넌트임
            - 하위 게임오브젝트를 드래그해서 넣으면 자동으로 해당 게임오브젝트의 `AudioSource`가 배정될 것임
2.  **코드 클린업**:
    * `PlayerStatController.cs`의 불필요한 디버그 로그를 제거함

## **기대 효과**

- **사운드 소스 관리 쉬워짐**: `SoundManager`와 `AudioSource`의 분리를 통해 더 여러개의 사운드 소스를 관리하기 쉬워졌음
