### PR TITLE
Feature/player death

### DIFF
--- a/Assets/Player/Animation/player_death.anim
+++ b/Assets/Player/Animation/player_death.anim
@@ -70,7 +70,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -81,7 +81,8 @@ public class PlayerMoveController : MonoBehaviour
     // 플레이어 입력에 따라 애니메이션 스프라이트를 뒤집는 메서드
     private void FlipCharacter(Vector2 input)
     {
-        if (input.x < 0) _spriteRenderer.flipX = true;
+        if (input.x == 0) return;
+        else if (input.x < 0) _spriteRenderer.flipX = true;
         else if (input.x > 0) _spriteRenderer.flipX = false;
     }
     

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -64,7 +64,7 @@ public class PlayerMoveController : MonoBehaviour
     public void SetMoveAnimation()
     {
         _currentPos = gameObject.transform.position;
-        transform.Translate(_moveVector.normalized * _moveSpeed * Time.deltaTime);
+        transform.Translate(MoveVector.normalized * _moveSpeed * Time.deltaTime);
         DefinePlayerAnimation(_currentPos, _lastPos);
         _lastPos = _currentPos;
     }
@@ -72,10 +72,10 @@ public class PlayerMoveController : MonoBehaviour
     // 플레이어 이동 처리하는 메서드
     public void OnMove(InputAction.CallbackContext context)
     {
-        _inputVector = context.ReadValue<Vector2>();
+        InputVector = context.ReadValue<Vector2>();
         
         // 프로퍼티에서 set 로직에 선언한 대로, 죽은 상태라면 알아서 Vector3.zero를 대입한다.
-        MoveVector = new Vector3(_inputVector.x, _inputVector.y, 0);
+        MoveVector = new Vector3(InputVector.x, InputVector.y, 0);
     }
     
     // 플레이어 입력에 따라 애니메이션 스프라이트를 뒤집는 메서드
@@ -89,7 +89,6 @@ public class PlayerMoveController : MonoBehaviour
     void DefinePlayerAnimation(Vector2 lastPosition, Vector2 nowPosition)
     {
         _animator.SetBool("isMoving", (lastPosition != nowPosition));
-        FlipCharacter(_inputVector);
+        FlipCharacter(InputVector);
     }
 }
-

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -39,6 +39,16 @@ public class PlayerMoveController : MonoBehaviour
         }
     }
     
+    public Vector3 InputVector
+    {
+        get {return _inputVector;}
+        set
+        {
+            // 사망 상태라면 외부에서 어떤 값을 넣으려고 해도 0으로 고정
+            if (PlayerManager.Instance.PlayerStatController.Dead == true) _inputVector = Vector3.zero;
+            else _inputVector = value;
+        }
+    }
     
     public void SetUp()
     {

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -20,7 +20,7 @@ public class PlayerMoveController : MonoBehaviour
     private float _moveSpeed;
     // 유저 입력을 저장할 2차원 벡터 변수
     private Vector2 _inputVector;
-    private Vector3 _moveVector;
+    private Vector2 _moveVector;
     // 플레이어 위치 기록용 2차원 벡터 변수들
     // 마지막 위치
     private Vector2 _lastPos;
@@ -28,24 +28,24 @@ public class PlayerMoveController : MonoBehaviour
     private Vector2 _currentPos;
     
     // 프로퍼티
-    public Vector3 MoveVector
+    public Vector2 MoveVector
     {
         get {return _moveVector;}
         set
         {
             // 사망 상태라면 외부에서 어떤 값을 넣으려고 해도 0으로 고정
-            if (PlayerManager.Instance.PlayerStatController.Dead == true) _moveVector = Vector3.zero;
+            if (PlayerManager.Instance.PlayerStatController.Dead == true) _moveVector = Vector2.zero;
             else _moveVector = value;
         }
     }
     
-    public Vector3 InputVector
+    public Vector2 InputVector
     {
         get {return _inputVector;}
         set
         {
             // 사망 상태라면 외부에서 어떤 값을 넣으려고 해도 0으로 고정
-            if (PlayerManager.Instance.PlayerStatController.Dead == true) _inputVector = Vector3.zero;
+            if (PlayerManager.Instance.PlayerStatController.Dead == true) _inputVector = Vector2.zero;
             else _inputVector = value;
         }
     }
@@ -75,7 +75,7 @@ public class PlayerMoveController : MonoBehaviour
         InputVector = context.ReadValue<Vector2>();
         
         // 프로퍼티에서 set 로직에 선언한 대로, 죽은 상태라면 알아서 Vector3.zero를 대입한다.
-        MoveVector = new Vector3(InputVector.x, InputVector.y, 0);
+        MoveVector = new Vector2(InputVector.x, InputVector.y);
     }
     
     // 플레이어 입력에 따라 애니메이션 스프라이트를 뒤집는 메서드

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -21,12 +21,24 @@ public class PlayerMoveController : MonoBehaviour
     // 유저 입력을 저장할 2차원 벡터 변수
     private Vector2 _inputVector;
     private Vector3 _moveVector;
-    
     // 플레이어 위치 기록용 2차원 벡터 변수들
     // 마지막 위치
     private Vector2 _lastPos;
     // 현재 위치
     private Vector2 _currentPos;
+    
+    // 프로퍼티
+    public Vector3 MoveVector
+    {
+        get {return _moveVector;}
+        set
+        {
+            // 사망 상태라면 외부에서 어떤 값을 넣으려고 해도 0으로 고정
+            if (PlayerManager.Instance.PlayerStatController.Dead == true) _moveVector = Vector3.zero;
+            else _moveVector = value;
+        }
+    }
+    
     
     public void SetUp()
     {
@@ -50,14 +62,10 @@ public class PlayerMoveController : MonoBehaviour
     // 플레이어 이동 처리하는 메서드
     public void OnMove(InputAction.CallbackContext context)
     {
-        bool isDead = PlayerManager.Instance.PlayerStatController.Dead;
-        if (isDead == true)
-        {
-            _moveVector = Vector3.zero;
-            return;
-        }
         _inputVector = context.ReadValue<Vector2>();
-        _moveVector = new Vector3(_inputVector.x, _inputVector.y, 0);
+        
+        // 프로퍼티에서 set 로직에 선언한 대로, 죽은 상태라면 알아서 Vector3.zero를 대입한다.
+        MoveVector = new Vector3(_inputVector.x, _inputVector.y, 0);
     }
     
     // 플레이어 입력에 따라 애니메이션 스프라이트를 뒤집는 메서드

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -74,7 +74,7 @@ public class PlayerMoveController : MonoBehaviour
     {
         InputVector = context.ReadValue<Vector2>();
         
-        // 프로퍼티에서 set 로직에 선언한 대로, 죽은 상태라면 알아서 Vector3.zero를 대입한다.
+        // 프로퍼티에서 set 로직에 선언한 대로, 죽은 상태라면 알아서 Vector2.zero를 대입한다.
         MoveVector = new Vector2(InputVector.x, InputVector.y);
     }
     

--- a/Assets/Player/Scripts/PlayerMoveController.cs
+++ b/Assets/Player/Scripts/PlayerMoveController.cs
@@ -50,6 +50,12 @@ public class PlayerMoveController : MonoBehaviour
     // 플레이어 이동 처리하는 메서드
     public void OnMove(InputAction.CallbackContext context)
     {
+        bool isDead = PlayerManager.Instance.PlayerStatController.Dead;
+        if (isDead == true)
+        {
+            _moveVector = Vector3.zero;
+            return;
+        }
         _inputVector = context.ReadValue<Vector2>();
         _moveVector = new Vector3(_inputVector.x, _inputVector.y, 0);
     }

--- a/Assets/Player/Scripts/PlayerStatController.cs
+++ b/Assets/Player/Scripts/PlayerStatController.cs
@@ -145,6 +145,6 @@ public class PlayerStatController : MonoBehaviour
     {
         // 플레이어 애니메이터 사망 트리거 실행
         _animator.SetBool("isDead", Dead);
-        PlayerManager.Instance.PlayerMoveController.MoveVector = Vector3.zero;
+        PlayerManager.Instance.PlayerMoveController.MoveVector = Vector2.zero;
     }
 }

--- a/Assets/Player/Scripts/PlayerStatController.cs
+++ b/Assets/Player/Scripts/PlayerStatController.cs
@@ -120,7 +120,6 @@ public class PlayerStatController : MonoBehaviour
             Debug.LogError("애니메이터 비어있음");
             return;
         }
-        
 
         if (_sm != null && playerSound != null) _sm.PlayPlayerSFX(playerSound.GetClip(0));
         else if (_sm == null) Debug.LogError("사운드매니저 null");
@@ -138,7 +137,13 @@ public class PlayerStatController : MonoBehaviour
     public void CheckDead()
     {
         Dead = CheckHpZero();
-        PlayerManager.Instance.Animator.SetBool("isDead", Dead);
+        if (Dead == true) PlayerDeadSequence();
+    }
+    
+    // 플레이어가 죽으면 실행할 효과들
+    public void PlayerDeadSequence()
+    {
+        // 플레이어 애니메이터 사망 트리거 실행
         _animator.SetBool("isDead", Dead);
     }
 }

--- a/Assets/Player/Scripts/PlayerStatController.cs
+++ b/Assets/Player/Scripts/PlayerStatController.cs
@@ -145,5 +145,6 @@ public class PlayerStatController : MonoBehaviour
     {
         // 플레이어 애니메이터 사망 트리거 실행
         _animator.SetBool("isDead", Dead);
+        PlayerManager.Instance.PlayerMoveController.MoveVector = Vector3.zero;
     }
 }

--- a/Assets/Scenes/PlayerScene.unity
+++ b/Assets/Scenes/PlayerScene.unity
@@ -326,6 +326,67 @@ PrefabInstance:
       addedObject: {fileID: 346130979}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+--- !u!1001 &1671227263
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5465676831210145756, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: _projDamage
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_Name
+      value: EnemyProjectile (for playerDie)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
 --- !u!1001 &1811623332
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -565,5 +626,6 @@ SceneRoots:
   - {fileID: 594040554}
   - {fileID: 1235735846}
   - {fileID: 1811623332}
+  - {fileID: 1671227263}
   - {fileID: 217228043390551019}
   - {fileID: 3686196720106666414}


### PR DESCRIPTION
## 개요
- 플레이어 사망 기능을 구현함

## 영상 자료
https://github.com/user-attachments/assets/9e304878-2daf-4b08-ae35-6c905b744db9

## 주요 변경 내역
- 사망 로직을 구현
  - 플레이어 사망 시 이동을 차단하고, `Vector3.zero`로 설정하도록 구현함
- 플레이어 사망 애니메이션 루프 수정
  - 플레이어 사망 시 애니메이션이 한 번만 출력되도록 수정함
  - 플레이어 사망 이후에는 이동 버튼을 누르더라도 좌, 우 반전이 되지 않으며, 바라보던 방향을 계속해서 바라봄
- 리팩토링
  - `PlayerMoveController.cs`에서 이동 관련 벡터 변수(`_inputVector`, `_moveVector`)의 public 프로퍼티를 두 개 만듬
  - 두 프로퍼티 모두 플레이어가 사망한 상태일 경우 어떤 변수를 입력하더라도 `Vector3.zero`가 입력되도록 설정함
- 테스트 환경
  - 플레이어를 즉시 죽게 만드는 임시 적 투사체를 씬에 추가함
    - 새로운 프리팹은 아니며, 프리팹의 데미지 수치를 조정해 씬에 배치만 한 것임

## 참고 사항
- 외부 스크립트에서 플레이어 입력이나 캐릭터 움직임 관련 변수를 가져올 일이 있을 경우, `PlayerMoveController.cs`의 `InputVector` 프로퍼티와 `MoveVector` 프로퍼티를 참조하도록 함
- 플레이어가 사망한 이후에도 주변에 적이 있으면 계속해서 총알을 발사하는 문제가 여전히 남아 있음
  - 해당 문제의 경우, 단순히 '사망 시스템을 구현한다'는 이번 PR의 취지에서 벗어나 무기까지 조정해야 하는 문제이므로, 이슈 #14로 저장해두고 해결은 보류해둘 예정임
  - 의도에서 벗어나는 것이지, 플레이가 불가능해지는 치명적인 버그는 아님
