### PR TITLE
플레이어 부활 기능 완성(애니메이션 미구현)

### DIFF
--- a/Assets/01.Scenes/TestScenes/PlayerReviveScene.unity
+++ b/Assets/01.Scenes/TestScenes/PlayerReviveScene.unity
@@ -1,0 +1,763 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!4 &300778758 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+  m_PrefabInstance: {fileID: 1235735846}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &345063789
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5465676831210145756, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: _projDamage
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_Name
+      value: EnemyProjectile (for playerDie) (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+--- !u!4 &346130979 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+  m_PrefabInstance: {fileID: 1253837010073346558}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &594040551
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 594040554}
+  - component: {fileID: 594040553}
+  - component: {fileID: 594040552}
+  - component: {fileID: 594040555}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &594040552
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594040551}
+  m_Enabled: 1
+--- !u!20 &594040553
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594040551}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &594040554
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594040551}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &594040555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594040551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalCameraData
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1001 &1235735846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 346130979}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+--- !u!1001 &1671227263
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5465676831210145756, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: _projDamage
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_Name
+      value: EnemyProjectile (for playerDie)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+--- !u!1001 &1710357851
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5465676831210145756, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: _projDamage
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_Name
+      value: EnemyProjectile (for playerDie) (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+--- !u!1001 &1811623332
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 532746457866965586, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_Name
+      value: EnemyProjectile
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178846134306271934, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d93df792072a74bbbee674226c1c49, type: 3}
+--- !u!1001 &217228043390551019
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 162642701154191956, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8056616088733125454, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+      propertyPath: m_Name
+      value: SoundManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ab73f57e8ea396b44b36fa026b9e6c68, type: 3}
+--- !u!1001 &1253837010073346558
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 300778758}
+    m_Modifications:
+    - target: {fileID: 2434694142653457009, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_Name
+      value: AutoRifle
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+--- !u!1001 &3686196720106666414
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5471180742016223411, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: enemyHp
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875285538776505495, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_Name
+      value: EnemyExample
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875285538776505495, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6312766285458507689, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4c4ac6e84d832e94ebcbdeaa236966be, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 594040554}
+  - {fileID: 1235735846}
+  - {fileID: 1811623332}
+  - {fileID: 1671227263}
+  - {fileID: 1710357851}
+  - {fileID: 345063789}
+  - {fileID: 217228043390551019}
+  - {fileID: 3686196720106666414}

--- a/Assets/01.Scenes/TestScenes/PlayerReviveScene.unity.meta
+++ b/Assets/01.Scenes/TestScenes/PlayerReviveScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f7c510a12a580df4fbe7efd2ef356a97
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -200,5 +200,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     {
         bool canRevive = Life > 0;
         Debug.Log($"목숨 {Life}개, 부활 {(canRevive ? "가능" : "불가능")}");
+        return canRevive;
     }
 }

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -148,5 +148,36 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         // 플레이어 애니메이터 사망 트리거 실행
         _animator.SetBool("isDead", Dead);
         PlayerManager.Instance.PlayerMoveController.MoveVector = Vector2.zero;
+        PlayerRevive();
+    }
+    // 플레이어 부활시키는 메서드
+    private void PlayerRevive()
+    {
+        if (CheckRevivable() == true)
+        {
+            Life -= 1;
+            Dead = false;
+            PlayerManager.Instance.Animator.SetBool("isDead", Dead);
+            Debug.Log("플레이어 부활 완료");
+        }
+        else
+        {
+            Debug.Log("플레이어 사망");
+        }
+    }
+    
+    // 부활 가능한지 판단하는 메서드
+    private bool CheckRevivable()
+    {
+        if (Life > 0)
+        {
+            Debug.Log($"목숨 {Life}개. 부활 가능. -1 줄일 예정");
+            return true;
+        }
+        else
+        {
+            Debug.Log($"목숨 {Life}개, 부활 불가능");
+            return false;
+        }
     }
 }

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -171,7 +171,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     private IEnumerator AfterReviveDelay()
     {
         Animator animator = PlayerManager.Instance.Animator;
-        animator.SetBool("isDead", true);
         
         yield return _reviveDelayWaitAction;
         PlayerReviveStatusSetting();

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -16,6 +16,10 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     [SerializeField]
     private SoundData playerSound;
     
+    // 제미나이의 조언으로 추가.
+    // 사망 후 부활 전에 사망 애니메이션이 출력되는 시간을 마련하기 위해 캐싱해두는 변수
+    private WaitForSeconds _reviveDelayWaitAction;
+    
     // 플레이어 스탯
     
     private int _currentLevel;
@@ -71,6 +75,9 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         resetPlayerStat();
         _animator = PlayerManager.Instance.Animator;
         _sm = SoundManager.Instance;
+        
+        // 부활까지 걸리는 시간 캐싱하여 재사용
+        _reviveDelayWaitAction = new WaitForSeconds(ReviveDelayTime);
     }
 
     //플레이어 데이터를 스크립터블 오브젝트에 있는 걸로 초기화하는 메서드
@@ -166,7 +173,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         Animator animator = PlayerManager.Instance.Animator;
         animator.SetBool("isDead", true);
         
-        yield return new WaitForSeconds(ReviveDelayTime);
+        yield return _reviveDelayWaitAction;
         PlayerReviveStatusSetting();
     }
 

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -170,8 +170,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     
     private IEnumerator AfterReviveDelay()
     {
-        Animator animator = PlayerManager.Instance.Animator;
-        
         yield return _reviveDelayWaitAction;
         PlayerReviveStatusSetting();
     }
@@ -185,7 +183,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
             Life -= 1;
             Dead = false;
             // 사망 애니메이션 출력을 위한 설정
-            PlayerManager.Instance.Animator.SetBool("isDead", false);
+            _animator.SetBool("isDead", false);
             // 체력 최대 체력으로 초기화
             CurrentHp = MaxHp;
             Debug.Log($"부활 후 남은 목숨: {Life}, 플레이어 부활함");

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -191,7 +191,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         else
         {
             Debug.Log("플레이어 사망");
-            // 게임 오버 알리는 이벤트 추가
+            // TODO: 게임 오버 알리는 이벤트 추가
         }
     }
     

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -2,6 +2,7 @@
 플레이어 캐릭터의 게임 플레이 도중의 상태 변화, 성장 등을 관리하는 스크립트
 */
 using System;
+using System.Collections;
 using Unity.Mathematics;
 using Unity.VisualScripting;
 using UnityEngine;
@@ -45,6 +46,15 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     public int Life {get => _life; set => _life = value;}
     private bool _dead = false;
     public bool Dead {get => _dead; set => _dead = value;}
+    
+    // 플레이어 부활까지 걸리는 시간이기 때문에 조정할 필요가 있음. 따라서 SerializeField를 적용함.
+    [SerializeField]
+    private float _reviveDelayTime = 1.5f;
+    public float ReviveDelayTime
+    {
+        get => _reviveDelayTime;
+        set => _reviveDelayTime = (value <= 0) ? 0 : value;
+    }
     private int _weaponSlotSize;
     public int WeaponSlotSize {get => _weaponSlotSize; set => _weaponSlotSize = value;}
     private int _passiveItemSlotSize;
@@ -148,17 +158,28 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         // 플레이어 애니메이터 사망 트리거 실행
         _animator.SetBool("isDead", Dead);
         PlayerManager.Instance.PlayerMoveController.MoveVector = Vector2.zero;
-        PlayerRevive();
+        StartCoroutine(AfterReviveDelay());
     }
-    // 플레이어 부활시키는 메서드
-    private void PlayerRevive()
+    
+    private IEnumerator AfterReviveDelay()
+    {
+        Animator animator = PlayerManager.Instance.Animator;
+        animator.SetBool("isDead", true);
+        
+        yield return new WaitForSeconds(ReviveDelayTime);
+        PlayerReviveStatusSetting();
+    }
+
+    // 플레이어 부활시킬 때 스탯 변화를 적용할 메서드
+    private void PlayerReviveStatusSetting()
     {
         if (CheckRevivable() == true)
         {
             // 목숨 차감
             Life -= 1;
             Dead = false;
-            PlayerManager.Instance.Animator.SetBool("isDead", Dead);
+            // 사망 애니메이션 출력을 위한 설정
+            PlayerManager.Instance.Animator.SetBool("isDead", false);
             // 체력 최대 체력으로 초기화
             CurrentHp = MaxHp;
             Debug.Log($"부활 후 남은 목숨: {Life}, 플레이어 부활함");

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -179,7 +179,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     // 플레이어 부활시킬 때 스탯 변화를 적용할 메서드
     private void PlayerReviveStatusSetting()
     {
-        if (CheckRevivable() == true)
+        if (CheckRevivable())
         {
             // 목숨 차감
             Life -= 1;

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -198,15 +198,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     // 부활 가능한지 판단하는 메서드
     private bool CheckRevivable()
     {
-        if (Life > 0)
-        {
-            Debug.Log($"목숨 {Life}개, 부활 가능");
-            return true;
-        }
-        else
-        {
-            Debug.Log($"목숨 {Life}개, 부활 불가능");
-            return false;
-        }
+        bool canRevive = Life > 0;
+        Debug.Log($"목숨 {Life}개, 부활 {(canRevive ? "가능" : "불가능")}");
     }
 }

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -155,14 +155,18 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     {
         if (CheckRevivable() == true)
         {
+            // 목숨 차감
             Life -= 1;
             Dead = false;
             PlayerManager.Instance.Animator.SetBool("isDead", Dead);
+            // 체력 최대 체력으로 초기화
+            CurrentHp = MaxHp;
             Debug.Log("플레이어 부활 완료");
         }
         else
         {
             Debug.Log("플레이어 사망");
+            // 게임 오버 알리는 이벤트 추가
         }
     }
     

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -161,7 +161,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
             PlayerManager.Instance.Animator.SetBool("isDead", Dead);
             // 체력 최대 체력으로 초기화
             CurrentHp = MaxHp;
-            Debug.Log("플레이어 부활 완료");
+            Debug.Log($"부활 후 남은 목숨: {Life}, 플레이어 부활함");
         }
         else
         {
@@ -175,7 +175,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     {
         if (Life > 0)
         {
-            Debug.Log($"목숨 {Life}개. 부활 가능. -1 줄일 예정");
+            Debug.Log($"목숨 {Life}개, 부활 가능");
             return true;
         }
         else

--- a/Assets/06.Animations/Player/Animator/playerAnimator.controller
+++ b/Assets/06.Animations/Player/Animator/playerAnimator.controller
@@ -245,7 +245,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 1
   m_HasExitTime: 1
@@ -378,7 +378,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 1
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/06.Animations/Player/Animator/playerAnimator.controller
+++ b/Assets/06.Animations/Player/Animator/playerAnimator.controller
@@ -45,7 +45,7 @@ AnimatorStateMachine:
     m_Position: {x: 420, y: 240, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5698019857060831739}
-    m_Position: {x: 1050, y: 110, z: 0}
+    m_Position: {x: 720, y: 10, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6679527619582069442}
     m_Position: {x: 720, y: 110, z: 0}
@@ -228,6 +228,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &3083549427402797021
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8810519049493843857}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &5638663134480419289
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -263,7 +288,8 @@ AnimatorState:
   m_Name: player_death
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 3083549427402797021}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -351,8 +377,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   m_SeeAllPackageVersions: 0
   m_DismissPreviewPackagesInUse: 0
   oneTimeWarningShown: 0
-  oneTimePackageErrorsPopUpShown: 0
+  oneTimePackageErrorsPopUpShown: 1
   m_Registries:
   - m_Id: main
     m_Name: 
@@ -35,6 +35,6 @@ MonoBehaviour:
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -916
-    m_OriginalInstanceId: -918
+    m_UserModificationsInstanceId: -892
+    m_OriginalInstanceId: -894
   m_LoadAssets: 0


### PR DESCRIPTION
## 개요
플레이어 부활 기능 구현

## 영상 자료

https://github.com/user-attachments/assets/014caa23-b926-4cbe-b498-cb03b538adf7

## 주요 변경 내역
- 플레이어의 부활 기능을 구현함
- 플레이어는 부활할 때마다 `Life` 프로퍼티 값을 1씩 줄이고 부활함
  - 부활은 코루틴 기능으로 구현됨
    - 사망 애니메이션이 출력되는 시간을 마련해주기 위함임
- 플레이어의 `Life`가 0 이하인 상태에서 사망한 플레이어는 부활할 수 없음
  - 이후 게임 오버 단계로 넘어가야겠지만, 아직 게임 오버를 관리하는 시스템 자체를 구현하지 않았음

## 참고 사항
- 이번에 브랜치를 파서 처음 작업을 시작했을 때부터 문제가 좀 생겼었음.
  - 이번 PR과는 관련이 없지만, 이번 작업에서 발견한 문제이기 때문에 이번 PR에서 보고함.
  - #19 이슈 확인을 부탁.
