### PR TITLE
feat : 기초 레벨 시스템 추가

### DIFF
--- a/Assets/01.Scenes/TestScenes/Level.unity
+++ b/Assets/01.Scenes/TestScenes/Level.unity
@@ -1,0 +1,424 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &381065005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.95147747
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4545228
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1356032557}
+  m_SourcePrefab: {fileID: 100100000, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+--- !u!1 &983246379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 983246380}
+  - component: {fileID: 983246381}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &983246380
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983246379}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.49007, y: 0.16414, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &983246381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983246379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 783c483876807d648b2a7c5df4cef0bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InGameManager
+--- !u!1 &1356032556 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+  m_PrefabInstance: {fileID: 381065005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1356032557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356032556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07d0006f0bf429d4f8069afc8f8723a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerLevelControl
+  currentLevel: 1
+  currentXP: 0
+  requiredXP: 0
+--- !u!1 &2033184848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2033184851}
+  - component: {fileID: 2033184850}
+  - component: {fileID: 2033184849}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2033184849
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033184848}
+  m_Enabled: 1
+--- !u!20 &2033184850
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033184848}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2033184851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033184848}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2077288208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2077288211}
+  - component: {fileID: 2077288210}
+  - component: {fileID: 2077288209}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2077288209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077288208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &2077288210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077288208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &2077288211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077288208}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2033184851}
+  - {fileID: 2077288211}
+  - {fileID: 983246380}
+  - {fileID: 381065005}

--- a/Assets/01.Scenes/TestScenes/Level.unity.meta
+++ b/Assets/01.Scenes/TestScenes/Level.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6a1b4a932623b749ba46424ad7a99cc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+
+public class PlayerLevelControl : MonoBehaviour
+{
+    [Header("Player Status")]
+    public int currentLevel = 1;
+    public float currentXP = 0;
+    public float requiredXP = 0;
+
+    void Start()
+    {
+        UpdateRequiredXP();
+    }
+
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
+        if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
+        if (Input.GetKeyDown(KeyCode.E)) AddXP(4);
+    }
+
+    public void AddXP(float amount)
+    {
+        currentXP += amount;
+        Debug.Log($"경험치 {amount} 획득 (현재: {currentXP} / {requiredXP})");
+
+        while (currentXP >= requiredXP)
+        {
+            LevelUp();
+        }
+    }
+
+    void LevelUp()
+    {
+        currentXP -= requiredXP;
+        currentLevel++;
+        UpdateRequiredXP();
+
+        Debug.Log($"LEVEL UP! 현재 레벨: {currentLevel}");
+
+        if (InGameManager.Instance != null)
+        {
+            InGameManager.Instance.OpenLevelUpUI();
+        }
+        else
+        {
+            Debug.LogError("InGameManager가 씬에 없습니다!");
+        }
+    }
+
+    void UpdateRequiredXP()
+    {
+        int L = currentLevel;
+
+        if (L >= 1 && L <= 15)
+        {
+            requiredXP = 8 * L + 10;
+        }
+        else if (L >= 16 && L <= 30)
+        {
+            requiredXP = 15 * L + 120;
+        }
+        else if (L >= 31 && L <= 50)
+        {
+            requiredXP = 30 * L + 300;
+        }
+        else
+        {
+            requiredXP = 2 * (L * L) + 500;
+        }
+    }
+}

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -1,23 +1,28 @@
+using System;
 using UnityEngine;
 
 public class PlayerLevelControl : MonoBehaviour
 {
     [Header("Player Status")]
-    public int currentLevel = 1;
-    public float currentXP = 0;
+    [SerializeField] public int currentLevel = 1;
+    [SerializeField] public float currentXP = 0;
     public float requiredXP = 0;
+
+    public event Action<int> OnLevelUp;
 
     void Start()
     {
         UpdateRequiredXP();
     }
 
+#if UNITY_EDITOR
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
         if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
         if (Input.GetKeyDown(KeyCode.E)) AddXP(4);
     }
+#endif
 
     public void AddXP(float amount)
     {
@@ -37,7 +42,7 @@ public class PlayerLevelControl : MonoBehaviour
         UpdateRequiredXP();
 
         Debug.Log($"LEVEL UP! 현재 레벨: {currentLevel}");
-
+        /*
         if (InGameManager.Instance != null)
         {
             InGameManager.Instance.OpenLevelUpUI();
@@ -46,21 +51,27 @@ public class PlayerLevelControl : MonoBehaviour
         {
             Debug.LogError("InGameManager가 씬에 없습니다!");
         }
+        */
+        OnLevelUp?.Invoke(currentLevel);
     }
 
     void UpdateRequiredXP()
     {
+        const int MaxLevelTier1 = 15;
+        const int MaxLevelTier2 = 30;
+        const int MaxLevelTier3 = 50;
+
         int L = currentLevel;
 
-        if (L >= 1 && L <= 15)
+        if (L <= MaxLevelTier1)
         {
             requiredXP = 8 * L + 10;
         }
-        else if (L >= 16 && L <= 30)
+        else if (L <= MaxLevelTier2)
         {
             requiredXP = 15 * L + 120;
         }
-        else if (L >= 31 && L <= 50)
+        else if (L <= MaxLevelTier3)
         {
             requiredXP = 30 * L + 300;
         }

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs.meta
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 07d0006f0bf429d4f8069afc8f8723a8

--- a/Assets/04.Scripts/UI/InGame/InGameManager.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameManager.cs
@@ -37,4 +37,18 @@ public class InGameManager : SingletonBehaviour<InGameManager>
         PlayTime += Time.deltaTime;
         InGameUIController.ShowPlayTime();
     }
+
+    public void OpenLevelUpUI()
+    {
+        {
+            if(InGameUIController != null)
+            {
+                InGameUIController.OpenLevelupUI();
+            }
+            else
+            {
+                Debug.LogError("UI 컨트롤러가 연결되지 않았습니다.");
+            }
+        }
+    }
 }

--- a/Assets/04.Scripts/UI/InGame/InGameManager.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameManager.cs
@@ -6,6 +6,8 @@ public class InGameManager : SingletonBehaviour<InGameManager>
 
     public float PlayTime { get; private set; }
 
+    private PlayerLevelControl _playerLevelControl;
+
     protected override void Init()
     {
         IsDestroyOnLoad = true;
@@ -24,9 +26,24 @@ public class InGameManager : SingletonBehaviour<InGameManager>
         }
 
         PlayTime = 0;
-        AudioManager.Instance.StopAll();
-        AudioManager.Instance.Play(AudioType.BGM, "InGameBGM");
+        // AudioManager.Instance.StopAll();
+        // AudioManager.Instance.Play(AudioType.BGM, "InGameBGM");
+
+        _playerLevelControl = FindAnyObjectByType<PlayerLevelControl>();
+        if (_playerLevelControl != null)
+        {
+            _playerLevelControl.OnLevelUp += OpenLevelUpUI;
+        }
     }
+
+    private void OnDestroy()
+    {
+        if (_playerLevelControl != null)
+        {
+            _playerLevelControl.OnLevelUp -= OpenLevelUpUI;
+        }
+    }
+
     private void Update()
     {
         RecordPlayTime();
@@ -38,17 +55,15 @@ public class InGameManager : SingletonBehaviour<InGameManager>
         InGameUIController.ShowPlayTime();
     }
 
-    public void OpenLevelUpUI()
+    public void OpenLevelUpUI(int level)
     {
+        if (InGameUIController != null)
         {
-            if(InGameUIController != null)
-            {
-                InGameUIController.OpenLevelupUI();
-            }
-            else
-            {
-                Debug.LogError("UI 컨트롤러가 연결되지 않았습니다.");
-            }
+            InGameUIController.OpenLevelupUI();
+        }
+        else
+        {
+            Debug.LogError("UI 컨트롤러가 연결되지 않았습니다.");
         }
     }
 }


### PR DESCRIPTION
# 📌개요
- 기본적인 레벨업 시스템 구현
- Q,W,E를 통해 몬스터의 등급에 맞는 레벨 경험치 부여

# 📜작업 내용
## PlayerLevelControl.cs 제작
- 경험치 공식을 이용하여 플레이어의 레벨 경험치가 Q : 1, W : 2, E : 4 씩 증가하도록 설정.
- 추후 몬스터와 사냥과 병합 시 몬스터의 등급에 따라 레벨업을 하는 것으로 변경 예정.

## Debug.Log를 통해 현재 상태 확인
- Q를 누를 경우 경험치 1 휙득
- W를 누를 경우 경험치 2 휙득
- E를 누를 경우 경험치 4 휙

# 📷관련 사진
- 레벨업, 경험치 관련 콘솔창
<img width="268" height="610" alt="스크린샷 2026-02-17 040028" src="https://github.com/user-attachments/assets/864fc882-14ef-4374-b9ea-55e443285d54" />

# 참고 사항
- 현재 Level 관련 시스템이 완벽하게 구현된 것은 X
- 몬스터의 사망 시 레벨을 증가시켜야 하기에, 아직은 레벨 공식을 이용하여 레벨업을 구현
- InGameManager호출해서 InGameUIController에 있는 OpenLevelUpUI()를 가져오게 하도록 Debug.Log를 통해 확인 가능. --> 없을 경우 Debug.logError에서 InGameManager가 씬에 없다는 것을 알려줌.