### PR TITLE
refactor: 주석 삭제 및 접근 지정자 추가

### DIFF
--- a/Assets/04.Scripts/Player/PlayerAnimationController.cs
+++ b/Assets/04.Scripts/Player/PlayerAnimationController.cs
@@ -24,7 +24,6 @@ public class PlayerAnimationController : MonoBehaviour
     {
         if(_playerEventController != null)
         {
-            // 중복 구독 문제를 피하기 위함
             RemoveFromEvent();
             AddToEvent();
         }
@@ -48,7 +47,6 @@ public class PlayerAnimationController : MonoBehaviour
     }
 
 #region 이벤트 메서드
-    // 등록할 이벤트의 목록
     private void AddToEvent()
     {
         _playerEventController.Hurt += OnEventHurt;
@@ -66,31 +64,23 @@ public class PlayerAnimationController : MonoBehaviour
         _playerEventController.Move -= OnEventMove;
         _playerEventController.Stop -= OnEventStop;
     }
-    // Hurt 이벤트에 추가할 메서드
     private void OnEventHurt()
     {
-        // _animator.SetTrigger("isHurt");
         _animator.SetTrigger(isHurtHash);
     }
     
-    // Death 이벤트에 추가할 메서드
     private void OnEventDeath()
     {
-        // _animator.SetBool("isDead", true);
         _animator.SetBool(isDeadHash, true);
     }
     
-    // Revive 이벤트에 추가할 메서드
     private void OnEventRevive()
     {
-        // _animator.SetBool("isDead", false);
         _animator.SetBool(isDeadHash, false);
     }
     
     private void OnEventMove()
     {
-        // Debug.Log("플레이어 이동 시작");
-        // _animator.SetBool("isMoving", true);
         _animator.SetBool(isMovingHash, true);
         if (_playerMoveController.InputVector.x < 0) _spriteRenderer.flipX = true;
         else if (_playerMoveController.InputVector.x > 0) _spriteRenderer.flipX = false;
@@ -98,8 +88,6 @@ public class PlayerAnimationController : MonoBehaviour
     
     private void OnEventStop()
     {
-        // Debug.Log("플레이어 이동 멈춤");
-        // _animator.SetBool("isMoving", false);
         _animator.SetBool(isMovingHash, false);
     }
 #endregion

--- a/Assets/04.Scripts/Player/PlayerEventController.cs
+++ b/Assets/04.Scripts/Player/PlayerEventController.cs
@@ -8,7 +8,6 @@ using UnityEngine;
 public class PlayerEventController : MonoBehaviour
 {
 #region PlayerStatusEvents
-    // 플레이어 상태 관련 이벤트
     public event Action Death, Revive, Hurt;
     
     public void CallDeath() => Death?.Invoke();
@@ -17,7 +16,6 @@ public class PlayerEventController : MonoBehaviour
 #endregion
 
 #region PlayerMoveEvents
-    // 플레이어 이동 관련 이벤트
     public event Action Move, Stop;
 
     public void CallMove() => Move?.Invoke();
@@ -25,7 +23,6 @@ public class PlayerEventController : MonoBehaviour
 #endregion
 
 #region PlayerItemEvents
-    // 플레이어 아이템 수집 관련 이벤트
     public event Action ScrapCollected;
 
     public void CallScrapCollected() => ScrapCollected?.Invoke();

--- a/Assets/04.Scripts/Player/PlayerItemController.cs
+++ b/Assets/04.Scripts/Player/PlayerItemController.cs
@@ -28,7 +28,7 @@ public class PlayerItemController : MonoBehaviour
         ResetItemSlots(statCon.WeaponSlotSize, statCon.PassiveItemSlotSize, statCon.TurretSlotSize);
     }
 
-    void ResetItemSlots(int weaponSlotSize, int passiveSlotSize, int turretSlotSize)
+    private void ResetItemSlots(int weaponSlotSize, int passiveSlotSize, int turretSlotSize)
     {
         InitializeSlots(_weaponSlot, weaponSlotSize);
         InitializeSlots(_passiveItemSlot, passiveSlotSize);

--- a/Assets/04.Scripts/Player/PlayerItemController.cs
+++ b/Assets/04.Scripts/Player/PlayerItemController.cs
@@ -22,14 +22,12 @@ public class PlayerItemController : MonoBehaviour
     private Dictionary<string, GameObject> _turretSlots = new Dictionary<string, GameObject>();
     [SerializeField] private int _turretSlotMaxCount = 7;
 
-    // 초기 설정 PlayerManager에서 받아오기
     public void SetUp()
     {
         PlayerStatController statCon = PlayerManager.Instance.PlayerStatController;
         ResetItemSlots(statCon.WeaponSlotSize, statCon.PassiveItemSlotSize, statCon.TurretSlotSize);
     }
 
-    // 아이템 슬롯 초기화하는 메서드
     void ResetItemSlots(int weaponSlotSize, int passiveSlotSize, int turretSlotSize)
     {
         InitializeSlots(_weaponSlot, weaponSlotSize);
@@ -38,7 +36,6 @@ public class PlayerItemController : MonoBehaviour
         Debug.Log("플레이어 아이템 슬롯 모두 초기화됨");
     }
 
-    // 빈 무기 슬롯이 있다면 아이템 넣는 메서드
     // 빈 무기 슬롯이 없다면 무기 교환해서 넣는 기능은 따로 구현하지 않는다.
     // 추가하려는 무기가 현재 무기 슬롯에 존재한다면 레벨만 올림.
     public void AddWeaponToSlot(WeaponStatData newWeaponData)

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -10,13 +10,13 @@ public class PlayerLevelControl : MonoBehaviour
 
     public event Action<int> OnLevelUp;
 
-    void Start()
+    private void Start()
     {
         UpdateRequiredXP();
     }
 
 #if UNITY_EDITOR
-    void Update()
+    private void Update()
     {
         if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
         if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
@@ -27,7 +27,7 @@ public class PlayerLevelControl : MonoBehaviour
     public void AddXP(float amount)
     {
         currentXP += amount;
-        Debug.Log($"°æÇèÄ¡ {amount} È¹µæ (ÇöÀç: {currentXP} / {requiredXP})");
+        Debug.Log($"ï¿½ï¿½ï¿½ï¿½Ä¡ {amount} È¹ï¿½ï¿½ (ï¿½ï¿½ï¿½ï¿½: {currentXP} / {requiredXP})");
 
         while (currentXP >= requiredXP)
         {
@@ -35,13 +35,13 @@ public class PlayerLevelControl : MonoBehaviour
         }
     }
 
-    void LevelUp()
+    private void LevelUp()
     {
         currentXP -= requiredXP;
         currentLevel++;
         UpdateRequiredXP();
 
-        Debug.Log($"LEVEL UP! ÇöÀç ·¹º§: {currentLevel}");
+        Debug.Log($"LEVEL UP! ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½: {currentLevel}");
         /*
         if (InGameManager.Instance != null)
         {
@@ -49,13 +49,13 @@ public class PlayerLevelControl : MonoBehaviour
         }
         else
         {
-            Debug.LogError("InGameManager°¡ ¾À¿¡ ¾ø½À´Ï´Ù!");
+            Debug.LogError("InGameManagerï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï´ï¿½!");
         }
         */
         OnLevelUp?.Invoke(currentLevel);
     }
 
-    void UpdateRequiredXP()
+    private void UpdateRequiredXP()
     {
         const int MaxLevelTier1 = 15;
         const int MaxLevelTier2 = 30;

--- a/Assets/04.Scripts/Player/PlayerManager.cs
+++ b/Assets/04.Scripts/Player/PlayerManager.cs
@@ -20,7 +20,7 @@ public class PlayerManager : MonoBehaviour
     public Animator Animator { get; private set; }
     public SpriteRenderer SpriteRenderer {get; private set; }
 
-    void Awake()
+    private void Awake()
     {
         if (SingleTonGenerate() == true)
         {
@@ -35,7 +35,7 @@ public class PlayerManager : MonoBehaviour
         }
     }
 
-    void Start()
+    private void Start()
     {
         if (Instance == this)
         {
@@ -44,12 +44,12 @@ public class PlayerManager : MonoBehaviour
         }
     }
 
-    void Update()
+    private void Update()
     {
         PlayerMoveController.MovePlayer();
     }
 
-    bool SingleTonGenerate()
+    private bool SingleTonGenerate()
     {
         if (Instance != null && Instance != this)
         {
@@ -61,7 +61,7 @@ public class PlayerManager : MonoBehaviour
         return true;
     }
 
-    void PlayerComponentSetup()
+    private void PlayerComponentSetup()
     {
         PlayerStatController.SetUp();
         PlayerMoveController.SetUp();

--- a/Assets/04.Scripts/Player/PlayerManager.cs
+++ b/Assets/04.Scripts/Player/PlayerManager.cs
@@ -8,10 +8,8 @@ using UnityEngine;
 
 public class PlayerManager : MonoBehaviour
 {
-    // 플레이어 매니저 싱글톤 전용
     public static PlayerManager Instance { get; private set; }
 
-    // 스크립트 컴포넌트들
     public PlayerMoveController PlayerMoveController { get; private set; }
     public PlayerStatController PlayerStatController { get; private set; }
     public PlayerItemController PlayerItemController { get; private set; }
@@ -72,6 +70,5 @@ public class PlayerManager : MonoBehaviour
         PlayerSoundController.SetUp();
     }
 
-    // 플레이어에게 데미지 입히는 메서드
     public void GetHurt(int dmg) => PlayerStatController.TakeDamage(dmg);
 }

--- a/Assets/04.Scripts/Player/PlayerMoveController.cs
+++ b/Assets/04.Scripts/Player/PlayerMoveController.cs
@@ -8,18 +8,13 @@ using UnityEngine.InputSystem;
 public class PlayerMoveController : MonoBehaviour
 {
 #region variables
-    // 플레이어 스프라이트 뒤집힘 여부 판단하기 위해서 가져옴
     private SpriteRenderer _spriteRenderer;
 
-    // 플레이어 이동 속도를 저장할 변수
     private float _moveSpeed;
-    // 유저 입력을 저장할 2차원 벡터 변수
     private Vector2 _inputVector;
     private Vector2 _moveVector;
-    // 플레이어 위치 기록용 2차원 벡터 변수들
-    // 마지막 위치
+
     private Vector2 _lastPos;
-    // 현재 위치
     private Vector2 _currentPos;
     
     private PlayerManager _playerManager;
@@ -33,7 +28,6 @@ public class PlayerMoveController : MonoBehaviour
         get {return _inputVector;}
         set
         {
-            // 사망 상태라면 외부에서 어떤 값을 넣으려고 해도 0으로 고정
             if (_playerStatController.Dead == true) _inputVector = Vector2.zero;
             else _inputVector = value;
             _inputVector.Normalize();
@@ -61,7 +55,6 @@ public class PlayerMoveController : MonoBehaviour
         AddToEvent();
     }
     
-    // 스크립트 변수들에 할당하는 코드 모아둔 메서드
     private void ScriptVariableSetup()
     {
         _playerManager = PlayerManager.Instance;
@@ -69,7 +62,6 @@ public class PlayerMoveController : MonoBehaviour
         _playerEventController = _playerManager.PlayerEventController;
     }
     
-    // 일반 변수들에 할당하는 코드 모아둔 메서드
     private void normalVariableSetup()
     {
         _moveSpeed = _playerStatController.MoveSpeed;
@@ -97,7 +89,6 @@ public class PlayerMoveController : MonoBehaviour
 #endregion
 
 #region Input System Package 메서드
-    // 플레이어 이동 처리하는 메서드
     public void OnMove(InputAction.CallbackContext context)
     {
         if (_playerStatController.Dead) return;
@@ -106,7 +97,6 @@ public class PlayerMoveController : MonoBehaviour
 #endregion
 
 #region 메서드들
-    // 매 프레임마다 플레이어를 이동시키는 메서드(PlayerManager의 Update()에 선언해야 함)
     public void MovePlayer()
     {
         
@@ -118,7 +108,6 @@ public class PlayerMoveController : MonoBehaviour
         UpdatePosition();
     }
     
-    // 이전 위치와 현재 위치가 다르다면 true, 아니라면 false를 반환하는 메서드
     private bool CheckMove()
     {
         if (_lastPos != _currentPos)
@@ -133,13 +122,11 @@ public class PlayerMoveController : MonoBehaviour
         }
     }
     
-    // 위치 업데이트하는 메서드
     private void UpdatePosition()
     {
         _lastPos = _currentPos;
     }
 
-    // 플레이어 이동 관련 이벤트 판단해서 실행시키는 메서드
     public void InvokeMoveEvents(bool isMoving)
     {
         if (isMoving == true) _playerEventController.CallMove();

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -143,7 +143,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
             _playerEventController.CallDeath();
         }
     }
-    int CalculateReducedDmg(int damage, int defense)
+    private int CalculateReducedDmg(int damage, int defense)
     {
         float value = damage * 100 / (100 + defense);
         return (int)Math.Round(value);

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -17,14 +17,12 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     #endregion
     
     #region 플레이어 스탯 변수들
-    // 플레이어 스탯
     public int CurrentLevel {get; set;}
     public int CurrentExp { get; private set; }
     public int MaxHp {get; set;}
     public int CurrentHp {get; set;}
     public int Defense  {get; set;}
     public int HpGenSpeed {get; set;}
-    // 플레이어 스탯 반환 및 설정하는 함수
     public float MoveSpeed {get; set;}
     public float ItemGetRadius {get; set;}
     public float Luck {get; set;}
@@ -39,7 +37,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     #endregion
 
     #region 플레이어 부활 시간 관련 변수
-    // 플레이어 부활까지 걸리는 시간이기 때문에 조정할 필요가 있음. 따라서 SerializeField를 적용함
     [SerializeField]
     private float _reviveDelayTime = 1.5f;
     private float ReviveDelayTime
@@ -60,7 +57,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     {
         if (_playerEventController != null)
         {
-            // 혹시 모를 중복 구독 방지를 위함
             RemoveFromEvent();
             AddToEvent();
         }
@@ -71,8 +67,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         RemoveFromEvent();
     }
 
-    // 필요한 데이터를 PlayerManager에서 받아오는 메서드
-    // 매개변수로 받아오므로, 필요할 때마다 매개변수에 추가해야 함.
     public void SetUp()
     {
         resetPlayerStat();
@@ -82,7 +76,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     #endregion
     
     #region 이벤트 관련 메서드
-    // 이벤트에 추가하는 함수들
     private void AddToEvent()
     {
         _playerEventController.Death += AddToDeath;
@@ -95,7 +88,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         _playerEventController.Revive -= AddToRevive;
     }
 
-    // Death 이벤트 활성화 시 작동할 메서드
     private void AddToDeath()
     {
         Debug.Log("플레이어 사망");
@@ -104,7 +96,6 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         StartCoroutine(AfterDead());
     }
     
-    // Revive 이벤트 활성화 시 작동할 메서드
     private void AddToRevive()
     {
         Debug.Log("플레이어 부활");
@@ -114,10 +105,8 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     }
     #endregion
 
-    //플레이어 데이터를 스크립터블 오브젝트에 있는 걸로 초기화하는 메서드
     private void resetPlayerStat()
     {
-        // 플레이어 스테이터스
         CurrentLevel = playerDefaultData.DefaultLevel;
         MaxHp = playerDefaultData.DefaultMaxHP;
         CurrentHp = MaxHp;
@@ -131,24 +120,19 @@ public class PlayerStatController : MonoBehaviour, IDamageable
         Curse = playerDefaultData.DefaultCurse;
         Life = playerDefaultData.DefaultLife;
         
-        // 슬롯들
         WeaponSlotSize = playerDefaultData.DefaultWeaponSlotSize;
         PassiveItemSlotSize = playerDefaultData.DefaultPassiveItemSlotSize;
         TurretSlotSize = playerDefaultData.DefaultTurretSlotSize;
     }
     
     #region 플레이어 데미지 관련 메서드
-    //플레이어 hp에 데미지 가하는 함수
     // 플레이어의 hp를 치료하는 효과는 다른 함수로 구현하도록 한다.
     public void TakeDamage(int damage)
     {
-        // 플레이어가 이미 죽은 경우 메서드 미적용
         if (Dead == true) return;
 
-        // 플레이어 피격 이벤트 실행
         _playerEventController.CallHurt();
         
-        // 방어력 적용해서 데미지 적용
         int calcDmg = CalculateReducedDmg(damage, Defense);
         CurrentHp -= calcDmg;
         Debug.Log($"{calcDmg} 적용, 남은 체력: {CurrentHp}");

--- a/Assets/04.Scripts/Player/SoundManager.cs
+++ b/Assets/04.Scripts/Player/SoundManager.cs
@@ -5,7 +5,6 @@ public enum SoundType {Player, Enemy}
 
 public class SoundManager : MonoBehaviour
 {
-    // 싱글톤을 위한 스태틱 변수
     public static SoundManager Instance {get; private set;}
     
     [Header("Audio Sources")]
@@ -18,17 +17,14 @@ public class SoundManager : MonoBehaviour
 
     private void Awake()
     {
-        // 인스턴스가 비어있다면 자신을 할당
         if (Instance == null)
         {
             Instance = this;
             
-            //씬이 바뀌어도 파괴되지 않게 설정
             DontDestroyOnLoad(gameObject);
         }
         else
         {
-            // 이미 인스턴스가 존재한다면 새로 생성된 오브젝트 파괴
             Destroy(gameObject);
         }
     }

--- a/Assets/04.Scripts/Weapon/BulletAnimationController.cs
+++ b/Assets/04.Scripts/Weapon/BulletAnimationController.cs
@@ -32,7 +32,6 @@ public class BulletAnimationController : MonoBehaviour
         _bulletController.Remove -= OnEventRemove;
     }
     
-    // 생성될 때 실행될 코드
     private void OnEventGenerate()
     {
         if (_bulletAnimationClip == null)
@@ -46,14 +45,12 @@ public class BulletAnimationController : MonoBehaviour
         if(_animator != null) _animator.Play(_bulletAnimationClip.name, 0, 0f);
     }
     
-    // 적 맞았을 때 실행될 코드
     private void OnEventHit()
     {
         _spriteRenderer.enabled = false;
         _collider2D.enabled = false;
     }
     
-    // 총알 없어질 때(오브젝트 풀로 돌아가거나 삭제될 때) 실행될 코드
     private void OnEventRemove()
     {
         _spriteRenderer.enabled = true;

--- a/Assets/04.Scripts/Weapon/BulletController.cs
+++ b/Assets/04.Scripts/Weapon/BulletController.cs
@@ -36,12 +36,12 @@ public class BulletController : MonoBehaviour
     #endregion
     
     #region 참조변수
-    WaitForSeconds _delayForBulletDisable;
+    private WaitForSeconds _delayForBulletDisable;
     private SpriteRenderer _spriteRenderer;
     private Collider2D _collider2D;
     #endregion
 
-    void Awake()
+    private void Awake()
     {
         _spriteRenderer = GetComponent<SpriteRenderer>();
         _collider2D = GetComponent<Collider2D>();
@@ -56,7 +56,7 @@ public class BulletController : MonoBehaviour
     #endregion
 
     #region 유니티 생명주기 메서드
-    void OnEnable()
+    private void OnEnable()
     {
         _spriteRenderer.enabled = true;
         _collider2D.enabled = true;
@@ -65,13 +65,13 @@ public class BulletController : MonoBehaviour
         StartCoroutine(DeactivateAfterTime());
     }
 
-    void OnDisable()
+    private void OnDisable()
     {
         StopAllCoroutines();
         CallEventRemove();
     }
 
-    void Update() => transform.Translate(Vector2.right * _projectileSpeed * Time.deltaTime);
+    private void Update() => transform.Translate(Vector2.right * _projectileSpeed * Time.deltaTime);
     #endregion
 
     #region 스탯 설정 및 반환 메서드
@@ -98,7 +98,7 @@ public class BulletController : MonoBehaviour
         if (gameObject.activeSelf) _projectilePool.Release(gameObject);
     }
 
-    void OnTriggerEnter2D(Collider2D other)
+    private void OnTriggerEnter2D(Collider2D other)
     {
         if (other.CompareTag("Enemy") && gameObject.activeSelf)
         {

--- a/Assets/04.Scripts/Weapon/BulletController.cs
+++ b/Assets/04.Scripts/Weapon/BulletController.cs
@@ -37,8 +37,6 @@ public class BulletController : MonoBehaviour
     
     #region 참조변수
     WaitForSeconds _delayForBulletDisable;
-    #warning 적 피격음만큼 기다리게 하는 WaitForSeconds()를 캐싱해두는 변수가 있었으나, 일단은 임시로 사운드매니저에서 출력을 담당하므로 쓸 일이 없어 숨겨둠. 이후에 총알 착탄지점에서 소리가 들리도록 만들려면 이것을 사용하도록 함.
-    // WaitForSeconds _delayForHitSound;
     private SpriteRenderer _spriteRenderer;
     private Collider2D _collider2D;
     #endregion
@@ -51,16 +49,13 @@ public class BulletController : MonoBehaviour
     }
 
     #region 캐싱 메서드
-    // 각종 컴포넌트들을 캐싱하는 메서드들
     private void CashingWaitForSeconds()
     {
         _delayForBulletDisable = new WaitForSeconds(_lifeTime);
-        // if (_bulletSoundController.HitSound != null) _delayForHitSound = new WaitForSeconds(_bulletSoundController.HitSound.length);
     }
     #endregion
 
     #region 유니티 생명주기 메서드
-    // 투사체가 발사 시작되었을 때 출력할 코드들
     void OnEnable()
     {
         _spriteRenderer.enabled = true;

--- a/Assets/04.Scripts/Weapon/BulletSoundController.cs
+++ b/Assets/04.Scripts/Weapon/BulletSoundController.cs
@@ -39,7 +39,7 @@ public class BulletSoundController : MonoBehaviour
     #endregion
 
     #region 유니티 생명주기 메서드
-    void Awake()
+    private void Awake()
     {
         _bulletController = GetComponent<BulletController>();
     }

--- a/Assets/04.Scripts/Weapon/BulletSoundController.cs
+++ b/Assets/04.Scripts/Weapon/BulletSoundController.cs
@@ -34,7 +34,6 @@ public class BulletSoundController : MonoBehaviour
 
     private void OnEventHit()
     {
-        // 일단 임시로 사용. 지금은 방향에 맞춰 소리가 들리지 않는 모노 사운드로만 구현됨.
         SoundManager.Instance.PlaySFX(SoundType.Enemy, _hitSound);
     }
     #endregion

--- a/Assets/04.Scripts/Weapon/ScriptableObjects/WeaponStatData.cs
+++ b/Assets/04.Scripts/Weapon/ScriptableObjects/WeaponStatData.cs
@@ -32,8 +32,8 @@ public class WeaponStatData : ScriptableObject, IItemStatData
     
     [Header("무기 공격력")]
     [SerializeField]
-    private int atk;
-    public int Atk => atk;
+    private int damage;
+    public int Damage => damage;
     
     [Header("무기 치명타 확률")]
     [SerializeField]

--- a/Assets/04.Scripts/Weapon/WeaponEventController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponEventController.cs
@@ -1,8 +1,6 @@
 using System;
 using UnityEngine;
 
-public enum WeaponStat { Level, Atk, CritRate, CritMultiplier, EffectRate, AtkSpeed, AtkRange, ProjectileSpeed, ProjectileCount }
-
 public class WeaponEventController : MonoBehaviour
 {
     public event Action<WeaponStat> OnStatChanged;

--- a/Assets/04.Scripts/Weapon/WeaponManager.cs
+++ b/Assets/04.Scripts/Weapon/WeaponManager.cs
@@ -3,7 +3,6 @@ using Game.Types;
 using UnityEngine;
 using UnityEngine.Pool;
 
-// 스크립트 참조변수
 [RequireComponent(typeof(WeaponShootController))]
 [RequireComponent(typeof(WeaponStatController))]
 [RequireComponent(typeof(WeaponEventController))]
@@ -22,7 +21,6 @@ public class WeaponManager : MonoBehaviour
     CircleCollider2D _weaponRangeCollider;
     
     #region 스크립트 참조변수
-    // 스크립트 참조 변수
     WeaponShootController _weaponShootController;
     BulletController _bulletController;
     WeaponStatController _weaponStatController;
@@ -31,9 +29,7 @@ public class WeaponManager : MonoBehaviour
     #endregion
     
     #region 무기 스탯 변수
-
-    // 무기 스탯 변수
-    int _dmg;
+    int _damage;
     float _atkSpeed, _projectileSpeed;
     #endregion
 
@@ -61,7 +57,7 @@ public class WeaponManager : MonoBehaviour
 
     void Update()
     {
-        _weaponShootController.ShootProcedurePerUpdate(_dmg, _atkSpeed, _projectileSpeed);
+        _weaponShootController.ShootProcedurePerUpdate(_damage, _atkSpeed, _projectileSpeed);
     }
     #endregion
     
@@ -73,7 +69,7 @@ public class WeaponManager : MonoBehaviour
         }
         else if (type == WeaponStat.Atk)
         {
-            _dmg = _weaponStatController.Atk;
+            _damage = _weaponStatController.Atk;
         }
         else if (type == WeaponStat.ProjectileSpeed)
         {
@@ -81,7 +77,6 @@ public class WeaponManager : MonoBehaviour
         }
     }
 
-    // 필요한 스크립트들 참조하는 메서드
     void GetRequiredComponents()
     {
         if (!TryGetComponent<WeaponShootController>(out _weaponShootController))
@@ -95,11 +90,9 @@ public class WeaponManager : MonoBehaviour
         if (!TryGetComponent<WeaponSoundController>(out _weaponSoundController))
         Debug.Log($"{nameof(_weaponSoundController)}가 null임");
         
-        // 스탯 먼저 초기화
         _weaponStatController.SetUp(_baseStat, _weaponRangeCollider);
         GetWeaponStats();
         
-        // ShootController 초기화
         _weaponShootController.SetUp(_projectilePrefab);
         _weaponSoundController.SetUp();
 
@@ -108,12 +101,11 @@ public class WeaponManager : MonoBehaviour
     
     void GetWeaponStats()
     {
-        _dmg = _weaponStatController.Atk;
+        _damage = _weaponStatController.Atk;
         _atkSpeed = _weaponStatController.AtkSpeed;
         _projectileSpeed = _weaponStatController.ProjectileSpeed;
     }
 
-    // 총알 프리팹이 있는지 확인하고, 안에 BulletController 스크립트까지 있는지 확인하는 메서드
     BulletController InspectNullAndGetPrefabComponent()
     {
         BulletController bulletController;

--- a/Assets/04.Scripts/Weapon/WeaponManager.cs
+++ b/Assets/04.Scripts/Weapon/WeaponManager.cs
@@ -9,7 +9,7 @@ using UnityEngine.Pool;
 [RequireComponent(typeof(WeaponSoundController))]
 public class WeaponManager : MonoBehaviour
 {
-    IObjectPool<GameObject> _projectilePool;
+    private IObjectPool<GameObject> _projectilePool;
     
     [Header("투사체")]
     [SerializeField]
@@ -17,51 +17,51 @@ public class WeaponManager : MonoBehaviour
     
     [Header("무기 기본 데이터")]
     [SerializeField]
-    WeaponStatData _baseStat;
-    CircleCollider2D _weaponRangeCollider;
+    private WeaponStatData _baseStat;
+    private CircleCollider2D _weaponRangeCollider;
     
     #region 스크립트 참조변수
-    WeaponShootController _weaponShootController;
-    BulletController _bulletController;
-    WeaponStatController _weaponStatController;
-    WeaponEventController _weaponEventController;
-    WeaponSoundController _weaponSoundController;
+    private WeaponShootController _weaponShootController;
+    private BulletController _bulletController;
+    private WeaponStatController _weaponStatController;
+    private WeaponEventController _weaponEventController;
+    private WeaponSoundController _weaponSoundController;
     #endregion
     
     #region 무기 스탯 변수
-    int _damage;
-    float _atkSpeed, _projectileSpeed;
+    private int _damage;
+    private float _atkSpeed, _projectileSpeed;
     #endregion
 
     #region 유니티 생명주기 함수
-    void Awake()
+    private void Awake()
     {
         _bulletController = InspectNullAndGetPrefabComponent();
         GetRequiredComponents();
     }
 
-    void Start()
+    private void Start()
     {
     }
 
-    void OnEnable()
+    private void OnEnable()
     {
         _weaponEventController.OnStatChanged += HandleStatChanged;
     }
 
-    void OnDisable()
+    private void OnDisable()
     {
         _weaponEventController.OnStatChanged -= HandleStatChanged;
     }
 
 
-    void Update()
+    private void Update()
     {
         _weaponShootController.ShootProcedurePerUpdate(_damage, _atkSpeed, _projectileSpeed);
     }
     #endregion
     
-    void HandleStatChanged(WeaponStat type)
+    private void HandleStatChanged(WeaponStat type)
     {
         if (type == WeaponStat.AtkSpeed)
         {
@@ -77,7 +77,7 @@ public class WeaponManager : MonoBehaviour
         }
     }
 
-    void GetRequiredComponents()
+    private void GetRequiredComponents()
     {
         if (!TryGetComponent<WeaponShootController>(out _weaponShootController))
         Debug.Log($"{nameof(_weaponShootController)}가 null임");
@@ -99,14 +99,14 @@ public class WeaponManager : MonoBehaviour
         _projectilePool = _weaponShootController.ReturnObjectPool();
     }
     
-    void GetWeaponStats()
+    private void GetWeaponStats()
     {
         _damage = _weaponStatController.Atk;
         _atkSpeed = _weaponStatController.AtkSpeed;
         _projectileSpeed = _weaponStatController.ProjectileSpeed;
     }
 
-    BulletController InspectNullAndGetPrefabComponent()
+    private BulletController InspectNullAndGetPrefabComponent()
     {
         BulletController bulletController;
         if (_projectilePrefab == null)

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -10,19 +10,19 @@ using UnityEngine.Pool;
 
 public class WeaponShootController : MonoBehaviour
 {
-    IObjectPool<GameObject> _projectilePool;
-    GameObject _bulletPrefab;
-    CircleCollider2D _weaponRangeCollider;
-    List<GameObject> enemiesInRange = new List<GameObject>();
-    WeaponStatController _weaponStatController;
+    private IObjectPool<GameObject> _projectilePool;
+    private GameObject _bulletPrefab;
+    private CircleCollider2D _weaponRangeCollider;
+    private List<GameObject> enemiesInRange = new List<GameObject>();
+    private WeaponStatController _weaponStatController;
     
-    int _weaponDamage, _projectileCount;
-    float _atkCoolTime, _projectileSpeed = 0f;
+    private int _weaponDamage, _projectileCount;
+    private float _atkCoolTime, _projectileSpeed = 0f;
     [SerializeField]
     private float _dispersionAngle = 10f;
 
 
-    void Awake()
+    private void Awake()
     {   
         _projectilePool = new ObjectPool<GameObject>(
             createFunc: OnCreateBullet,
@@ -43,12 +43,12 @@ public class WeaponShootController : MonoBehaviour
 
     public IObjectPool<GameObject> ReturnObjectPool() => _projectilePool;
 
-    void OnTriggerEnter2D(Collider2D collision)
+    private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.CompareTag("Enemy")) enemiesInRange.Add(collision.gameObject);
     }
 
-    void OnTriggerExit2D(Collider2D collision)
+    private void OnTriggerExit2D(Collider2D collision)
     {
         if (collision.CompareTag("Enemy")) enemiesInRange.Remove(collision.gameObject);
     }
@@ -68,7 +68,7 @@ public class WeaponShootController : MonoBehaviour
         }
     }
 
-    void Shoot(int weaponDamage, float projSpeed)
+    private void Shoot(int weaponDamage, float projSpeed)
     {
         _weaponDamage = weaponDamage;
         _projectileSpeed = projSpeed;
@@ -85,7 +85,7 @@ public class WeaponShootController : MonoBehaviour
         }
     }
     
-    Vector2 FindClosestTargetVector(Vector2 playerPos)
+    private Vector2 FindClosestTargetVector(Vector2 playerPos)
     {
         if (enemiesInRange.Count == 0) return Vector2.zero;
         
@@ -107,15 +107,15 @@ public class WeaponShootController : MonoBehaviour
         return targetPos;
     }
 
-    Vector2 GetDirectionVector(Vector2 startPos, Vector2 endPos) => endPos - startPos;
+    private Vector2 GetDirectionVector(Vector2 startPos, Vector2 endPos) => endPos - startPos;
 
-    GameObject OnCreateBullet()
+    private GameObject OnCreateBullet()
     {
         GameObject obj = Instantiate(_bulletPrefab);
         return obj;
     }
     
-    void OnGetBullet(GameObject obj)
+    private void OnGetBullet(GameObject obj)
     {
         Vector2 playerPos = transform.position;
         obj.transform.position = playerPos;
@@ -138,10 +138,10 @@ public class WeaponShootController : MonoBehaviour
         }
     }
 
-    void OnReleaseBullet(GameObject obj)
+    private void OnReleaseBullet(GameObject obj)
     {
         obj.SetActive(false);
     }
     
-    void OnDestroyBullet(GameObject obj) => Destroy(obj);
+    private void OnDestroyBullet(GameObject obj) => Destroy(obj);
 }

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -25,45 +25,40 @@ public class WeaponShootController : MonoBehaviour
     void Awake()
     {   
         _projectilePool = new ObjectPool<GameObject>(
-            createFunc: OnCreateBullet,         // 객체 생성 로직
-            actionOnGet: OnGetBullet,           // 풀에서 꺼낼 때
-            actionOnRelease: OnReleaseBullet,   // 풀에 반납할 때
-            actionOnDestroy: OnDestroyBullet,   // 풀이 가득 찼을 때 파괴
-            collectionCheck: true,              // 중복 반납 체크(에디터용)
-            defaultCapacity: 10,                // 기본 크기
-            maxSize: 50                         // 최대 크기
+            createFunc: OnCreateBullet,
+            actionOnGet: OnGetBullet,
+            actionOnRelease: OnReleaseBullet,
+            actionOnDestroy: OnDestroyBullet,
+            collectionCheck: true,
+            defaultCapacity: 10,
+            maxSize: 50
         );
     }
     
-    // 초기화 메서드
     public void SetUp(GameObject bulletPrefab)
     {
         _bulletPrefab = bulletPrefab;
         _weaponStatController = GetComponent<WeaponStatController>();
     }
 
-    // 오브젝트 풀을 반환하는 메서드
     public IObjectPool<GameObject> ReturnObjectPool() => _projectilePool;
 
-    // 공격 범위에 들어오면
     void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.CompareTag("Enemy")) enemiesInRange.Add(collision.gameObject);
     }
 
-    // 공격 범위에서 나가면
     void OnTriggerExit2D(Collider2D collision)
     {
         if (collision.CompareTag("Enemy")) enemiesInRange.Remove(collision.gameObject);
     }
 
-    // 프레임당 실행해야 하는 사격 매커니즘
     public void ShootProcedurePerUpdate(int dmg, float atkSpeed, float projectileSpeed)
     {
         if (atkSpeed <= 0.01f)
         {
             Debug.LogError("공격속도가 지나치게 낮음");
-            return; // 공격속도가 지나치게 낮으면 게임 터지는걸 막기 위해서 강제 종료
+            return;
         }
         _atkCoolTime += Time.deltaTime;
         if (enemiesInRange.Count >= 1 && _atkCoolTime >= atkSpeed)
@@ -90,11 +85,6 @@ public class WeaponShootController : MonoBehaviour
         }
     }
     
-    // 플레이어와 위치가 가장 가까운 타겟의 위치 벡터 구하는 방법
-    /*
-    결과가 정상적이지 않을 경우 Vector2.zero를 출력하도록 코드를 작성했다.
-    따라서 거리가 0이라면 사격을 실행하지 않도록 하는 코드를 사격 코드에 추가해야 할 것이다.
-    */
     Vector2 FindClosestTargetVector(Vector2 playerPos)
     {
         if (enemiesInRange.Count == 0) return Vector2.zero;
@@ -117,27 +107,21 @@ public class WeaponShootController : MonoBehaviour
         return targetPos;
     }
 
-    // 매개변수 시작 위치에서 매개변수 도착 위치 방향의 벡터 구하는 메서드
     Vector2 GetDirectionVector(Vector2 startPos, Vector2 endPos) => endPos - startPos;
 
-    // 여기 아래부터는 오브젝트 풀링 관련 함수들 정리
-    // 총알을 생성해야 할 때
     GameObject OnCreateBullet()
     {
         GameObject obj = Instantiate(_bulletPrefab);
         return obj;
     }
     
-    // 오브젝트 풀링에서 꺼낼 때
     void OnGetBullet(GameObject obj)
     {
         Vector2 playerPos = transform.position;
         obj.transform.position = playerPos;
         
-        // 가장 가까운 타겟 찾기
         Vector2 targetPos = FindClosestTargetVector(playerPos);
         
-        // 오류가 뜬 경우
         if (targetPos == Vector2.zero)
         {
             Debug.LogError("적 발견 불가");
@@ -145,26 +129,19 @@ public class WeaponShootController : MonoBehaviour
             return;
         }
         
-        // 플레이어 위치를 시작점으로 하는 적 방향의 위치 벡터.
         Vector2 direction = GetDirectionVector(playerPos, targetPos).normalized;
         obj.transform.right = direction;
         
-        // 총알 스탯 결정
         if (obj.TryGetComponent<BulletController>(out var bulletController))
         {
             bulletController.SetUp(_dmg, _projectileSpeed, _projectilePool);
         }
-        
-        // 총알 생성 후 활성화 단계인데, 산탄 기능 활성화를 위해 해당 코드를 Shoot()으로 옮길 예정. 임시로 주석처리함.
-        // obj.SetActive(true);
     }
 
-    // 총알 없앨 때 적용할 메서드(오브젝트 풀로 다시 넣을 때)
     void OnReleaseBullet(GameObject obj)
     {
         obj.SetActive(false);
     }
     
-    // 총알 삭제할 때
     void OnDestroyBullet(GameObject obj) => Destroy(obj);
 }

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -16,7 +16,7 @@ public class WeaponShootController : MonoBehaviour
     List<GameObject> enemiesInRange = new List<GameObject>();
     WeaponStatController _weaponStatController;
     
-    int _dmg, _projectileCount;
+    int _weaponDamage, _projectileCount;
     float _atkCoolTime, _projectileSpeed = 0f;
     [SerializeField]
     private float _dispersionAngle = 10f;
@@ -53,7 +53,7 @@ public class WeaponShootController : MonoBehaviour
         if (collision.CompareTag("Enemy")) enemiesInRange.Remove(collision.gameObject);
     }
 
-    public void ShootProcedurePerUpdate(int dmg, float atkSpeed, float projectileSpeed)
+    public void ShootProcedurePerUpdate(int weaponDamage, float atkSpeed, float projectileSpeed)
     {
         if (atkSpeed <= 0.01f)
         {
@@ -64,13 +64,13 @@ public class WeaponShootController : MonoBehaviour
         if (enemiesInRange.Count >= 1 && _atkCoolTime >= atkSpeed)
         {
             _atkCoolTime = 0f;
-            Shoot(dmg, projectileSpeed);
+            Shoot(weaponDamage, projectileSpeed);
         }
     }
 
-    void Shoot(int dmg, float projSpeed)
+    void Shoot(int weaponDamage, float projSpeed)
     {
-        _dmg = dmg;
+        _weaponDamage = weaponDamage;
         _projectileSpeed = projSpeed;
         _projectileCount = (int)_weaponStatController.ProjectileCount;
         for (int i = 0; i < _projectileCount; i++)
@@ -134,7 +134,7 @@ public class WeaponShootController : MonoBehaviour
         
         if (obj.TryGetComponent<BulletController>(out var bulletController))
         {
-            bulletController.SetUp(_dmg, _projectileSpeed, _projectilePool);
+            bulletController.SetUp(_weaponDamage, _projectileSpeed, _projectilePool);
         }
     }
 

--- a/Assets/04.Scripts/Weapon/WeaponSoundController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponSoundController.cs
@@ -36,19 +36,16 @@ public class WeaponSoundController : MonoBehaviour
     }
     
     #region 이벤트 관련 변수
-    // 이벤트 구독
     private void AddToEvent()
     {
         _weaponEventController.OnShoot += OnEventOnShoot;
     }
     
-    // 이벤트 구독 해제
     private void RemoveFromEvent()
     {
         _weaponEventController.OnShoot -= OnEventOnShoot;
     }
     
-    // 발사 시 사운드 출력
     private void OnEventOnShoot()
     {
         if (ObjectIsNull(_audioSource, "AudioSource")) return;

--- a/Assets/04.Scripts/Weapon/WeaponStatController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponStatController.cs
@@ -61,7 +61,7 @@ public class WeaponStatController : MonoBehaviour, IItemStatController
     private void ResetWeaponData(WeaponStatData baseStat)
     {
         level = baseStat.Level;
-        atk = baseStat.Atk;
+        atk = baseStat.Damage;
         critRate = baseStat.CritRate;
         critMultiplier = baseStat.CritMultiplier;
         effectRate = baseStat.EffectRate;

--- a/Assets/04.Scripts/Weapon/WeaponStatController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponStatController.cs
@@ -43,7 +43,6 @@ public class WeaponStatController : MonoBehaviour, IItemStatController
     [SerializeField] private float projectileCount;
     public float ProjectileCount { get => projectileCount; set { projectileCount = value; _weaponEventController.CallOnStatChanged(WeaponStat.ProjectileCount); } }
 
-    // 무기 범위로 사용되는 콜라이더
     private CircleCollider2D _weaponRangeCollider;
     
     public int GetLevel()
@@ -57,7 +56,6 @@ public class WeaponStatController : MonoBehaviour, IItemStatController
         AtkSpeed = baseStat.AtkSpeed;
     }
 
-    // 스크립터블 오브젝트에 저장한 대로 무기 데이터 설정 완료
     private void ResetWeaponData(WeaponStatData baseStat)
     {
         level = baseStat.Level;


### PR DESCRIPTION
## 📌개요
issue #45의 목적인 쓸모 없는 주석 지우기 작업 완료
직관적이지 않은 변수의 이름도 몇가지 수정함

## 📜작업 내용
- 버그 수정
  - WeaponStat enum이 WeaponEventController.cs에서도 선언되어 문제가 발생했었음. WeaponStatController.cs에만 존재하도록 수정함.
- 변수명 수정
  - 무기 기초 스탯을 결정하는 스크립터블 오브젝트의 무기 데미지 변수는 직관적이지 않고 애매하다는 생각이 들었음. 그렇기에 해당 변수명을 직관적으로 느낄 수 있도록 수정함.
- 쓸모 없는 주석 다수 삭제
- 플레이어, 무기 관련 스크립트에서 접근 지정자가 생략된 변수, 메서드에 접근 지정자를 추가해줌.

## 📷시연 자료
따로 없음

## 참고 사항
참고 사항 없음