### PR TITLE
Feat : 레벨업 패시브 업그레이드 기능 추가

### DIFF
--- a/Assets/01.Scenes/TestScenes/Level.unity
+++ b/Assets/01.Scenes/TestScenes/Level.unity
@@ -119,7 +119,293 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &381065005
+--- !u!114 &67382738 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5503052194904763271, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &208259794 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+  m_PrefabInstance: {fileID: 1641758721}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &208259795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 208259794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07d0006f0bf429d4f8069afc8f8723a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerLevelControl
+  currentLevel: 1
+  currentXP: 0
+  requiredXP: 0
+--- !u!1 &593911049 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2457430659824835108, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &593911050 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &689684906 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2275436680573112103, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &746952559 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2218288526327122416, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+--- !u!114 &747695804 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4007994486916848439, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &823639493 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2391094122051603101, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &888586267 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3623420185678507825, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &983246379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 983246380}
+  - component: {fileID: 983246381}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &983246380
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983246379}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.49007, y: 0.16414, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1658844228}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &983246381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983246379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 783c483876807d648b2a7c5df4cef0bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InGameUIController_Test
+--- !u!1001 &1069911498
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1658844228}
+    m_Modifications:
+    - target: {fileID: 2457430659824835108, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_Name
+      value: LevelUPUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 2457430659824835108, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9176060536408910360, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+--- !u!114 &1131501988 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4512135337159603452, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1139009978 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4998949675097572428, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1527418695 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1388608153554130154, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1641442994 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7784584480585701003, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+--- !u!1001 &1641758721
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -133,11 +419,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.95147747
+      value: -2.12614
       objectReference: {fileID: 0}
     - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.4545228
+      value: 0.01822
       objectReference: {fileID: 0}
     - target: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       propertyPath: m_LocalPosition.z
@@ -177,9 +463,9 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1356032557}
+      addedObject: {fileID: 208259795}
   m_SourcePrefab: {fileID: 100100000, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
---- !u!1 &983246379
+--- !u!1 &1658844227
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -187,62 +473,200 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 983246380}
-  - component: {fileID: 983246381}
+  - component: {fileID: 1658844228}
+  - component: {fileID: 1658844231}
+  - component: {fileID: 1658844230}
+  - component: {fileID: 1658844229}
+  - component: {fileID: 1658844232}
   m_Layer: 0
-  m_Name: GameManager
+  m_Name: UICanvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &983246380
-Transform:
+--- !u!224 &1658844228
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 983246379}
-  serializedVersion: 2
+  m_GameObject: {fileID: 1658844227}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.49007, y: 0.16414, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
+  m_Children:
+  - {fileID: 593911050}
+  m_Father: {fileID: 983246380}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &983246381
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1658844229
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 983246379}
+  m_GameObject: {fileID: 1658844227}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 783c483876807d648b2a7c5df4cef0bf, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::InGameManager
---- !u!1 &1356032556 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
-  m_PrefabInstance: {fileID: 381065005}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1356032557
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1658844230
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1356032556}
+  m_GameObject: {fileID: 1658844227}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 07d0006f0bf429d4f8069afc8f8723a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::PlayerLevelControl
-  currentLevel: 1
-  currentXP: 0
-  requiredXP: 0
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1658844231
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1658844227}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1658844232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1658844227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5635845a8f02d44aba5f0995630ad74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InGameUIController
+  _pauseUI: {fileID: 0}
+  _endGameUI: {fileID: 0}
+  _levelupUI: {fileID: 593911049}
+  _playTimeUI: {fileID: 0}
+  _expBar: {fileID: 0}
+  _minimap: {fileID: 0}
+  _inGameUI: {fileID: 0}
+  _inGameVolume: {fileID: 0}
+  _itemSelectBtnDatas:
+  - ItemImage: {fileID: 747695804}
+    ItemNameText: {fileID: 67382738}
+    ItemLevelText: {fileID: 2015710650}
+    ItemDescriptionText: {fileID: 1881712991}
+  - ItemImage: {fileID: 1139009978}
+    ItemNameText: {fileID: 1131501988}
+    ItemLevelText: {fileID: 1527418695}
+    ItemDescriptionText: {fileID: 1679626149}
+  - ItemImage: {fileID: 1776720569}
+    ItemNameText: {fileID: 888586267}
+    ItemLevelText: {fileID: 689684906}
+    ItemDescriptionText: {fileID: 823639493}
+  _inventories: []
+  _itemSelectBtns:
+  - {fileID: 746952559}
+  - {fileID: 1641442994}
+  - {fileID: 1663212766}
+  _damageTextSpawner: {fileID: 0}
+  allPassives:
+  - {fileID: 11400000, guid: b3c0eeba4020ad54381f223819f5250e, type: 2}
+  - {fileID: 11400000, guid: 13765146ea933b147a7f6348ea5c5e46, type: 2}
+  - {fileID: 11400000, guid: 08453fe547c162f43a7069d5fa993958, type: 2}
+  _testEnemies: []
+--- !u!114 &1663212766 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6980240841359887686, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+--- !u!114 &1679626149 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3312526408165839184, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1776720569 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5298903217068089217, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1881712991 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6861483389234089515, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2015710650 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7027238557581822865, guid: 44c77088d11244a479938a040100b9dc, type: 3}
+  m_PrefabInstance: {fileID: 1069911498}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2033184848
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,6 +678,7 @@ GameObject:
   - component: {fileID: 2033184851}
   - component: {fileID: 2033184850}
   - component: {fileID: 2033184849}
+  - component: {fileID: 2033184852}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -335,6 +760,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2033184852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033184848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalCameraData
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
 --- !u!1 &2077288208
 GameObject:
   m_ObjectHideFlags: 0
@@ -421,4 +890,4 @@ SceneRoots:
   - {fileID: 2033184851}
   - {fileID: 2077288211}
   - {fileID: 983246380}
-  - {fileID: 381065005}
+  - {fileID: 1641758721}

--- a/Assets/02.Prefabs/UI/Canvas.prefab
+++ b/Assets/02.Prefabs/UI/Canvas.prefab
@@ -105,6 +105,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -243,6 +244,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -454,6 +456,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -742,6 +745,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -880,6 +884,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1244,6 +1249,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1612,6 +1618,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1750,6 +1757,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1888,6 +1896,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2335,6 +2344,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2473,6 +2483,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2687,6 +2698,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2823,6 +2835,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3110,6 +3123,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3321,6 +3335,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3457,6 +3472,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3593,6 +3609,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3850,6 +3867,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4033,6 +4051,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4290,6 +4309,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4428,6 +4448,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4865,6 +4886,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5115,6 +5137,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5251,6 +5274,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5464,6 +5488,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5751,6 +5776,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5889,6 +5915,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6027,6 +6054,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6331,6 +6359,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6619,6 +6648,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6830,6 +6860,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -7238,6 +7269,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -7680,6 +7712,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -8521,6 +8554,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -9050,6 +9084,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -9261,6 +9296,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -9625,6 +9661,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -9836,6 +9873,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -10129,6 +10167,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -10265,6 +10304,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -10403,6 +10443,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -10802,6 +10843,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -11593,6 +11635,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -11729,6 +11772,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -12191,6 +12235,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -12406,6 +12451,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -12622,6 +12668,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -12760,6 +12807,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -13207,6 +13255,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -13386,6 +13435,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -13980,6 +14030,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -14195,6 +14246,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -14333,6 +14385,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -14469,6 +14522,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -14722,6 +14776,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -14858,6 +14913,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -15266,6 +15322,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -15477,6 +15534,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -15615,6 +15673,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -15751,6 +15810,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -16269,6 +16329,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -16558,6 +16619,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -16694,6 +16756,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17058,6 +17121,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17194,6 +17258,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17330,6 +17395,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17468,6 +17534,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17680,6 +17747,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -17818,6 +17886,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -18262,6 +18331,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -18474,6 +18544,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -19187,6 +19258,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -19325,6 +19397,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -19616,6 +19689,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -20459,6 +20533,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -20708,6 +20783,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -20958,6 +21034,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -21437,6 +21514,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -21878,6 +21956,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -22016,6 +22095,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -22529,6 +22609,7 @@ MonoBehaviour:
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0

--- a/Assets/03.Data/Passive.meta
+++ b/Assets/03.Data/Passive.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 088adf064dd03b24ca0dff6f0cd3b67c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03.Data/Passive/Heart.asset
+++ b/Assets/03.Data/Passive/Heart.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3b4e24c8ec88c44a1b32d7f481e474, type: 3}
+  m_Name: Heart
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpPassive
+  itemName: "\uC778\uC870 \uC2EC\uC7A5"
+  icon: {fileID: 8581442000097331106, guid: 159cb2b7b70aecf4e9b2108f03c769c7, type: 3}
+  descriptionDesc: "\uCD5C\uB300 HP\uAC00 {0} \uC99D\uAC00\uD569\uB2C8\uB2E4."
+  passive: 0
+  maxLevel: 5
+  valuePerLevel:
+  - 20
+  - 40
+  - 60
+  - 80
+  - 100
+  valuePerLevel2: []

--- a/Assets/03.Data/Passive/Heart.asset.meta
+++ b/Assets/03.Data/Passive/Heart.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3c0eeba4020ad54381f223819f5250e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03.Data/Passive/Nuclear.asset
+++ b/Assets/03.Data/Passive/Nuclear.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3b4e24c8ec88c44a1b32d7f481e474, type: 3}
+  m_Name: Nuclear
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpPassive
+  itemName: "\uD734\uB300\uC6A9 \uC6D0\uC790\uB85C"
+  icon: {fileID: -9080757257801910307, guid: 98b40507cc6779e4b9b3b23e8003dedf, type: 3}
+  descriptionDesc: "\uACF5\uACA9\uB825\uC774 {0}% \uC99D\uAC00\uD569\uB2C8\uB2E4."
+  passive: 1
+  maxLevel: 5
+  valuePerLevel:
+  - 10
+  - 20
+  - 30
+  - 40
+  - 50
+  valuePerLevel2: []

--- a/Assets/03.Data/Passive/Nuclear.asset.meta
+++ b/Assets/03.Data/Passive/Nuclear.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13765146ea933b147a7f6348ea5c5e46
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03.Data/Passive/Sheild.asset
+++ b/Assets/03.Data/Passive/Sheild.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3b4e24c8ec88c44a1b32d7f481e474, type: 3}
+  m_Name: Sheild
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpPassive
+  itemName: "\uC5D0\uB108\uC9C0 \uC2E4\uB4DC"
+  icon: {fileID: -6236367840824913244, guid: afe275a488e08f14197173a7b02d9fb5, type: 3}
+  descriptionDesc: "\uBC29\uC5B4\uB825\uC774 {0} \uC99D\uAC00\uD569\uB2C8\uB2E4."
+  passive: 2
+  maxLevel: 5
+  valuePerLevel:
+  - 5
+  - 10
+  - 15
+  - 20
+  - 25
+  valuePerLevel2: []

--- a/Assets/03.Data/Passive/Sheild.asset.meta
+++ b/Assets/03.Data/Passive/Sheild.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08453fe547c162f43a7069d5fa993958
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Passive.meta
+++ b/Assets/04.Scripts/Passive.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a157b857f6cd3b468397c0fba7cdc0b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Passive/LevelUPUI.prefab
+++ b/Assets/04.Scripts/Passive/LevelUPUI.prefab
@@ -1,0 +1,1993 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &64394767353640818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8803166349975510642}
+  - component: {fileID: 5945278182731388996}
+  m_Layer: 5
+  m_Name: Btns
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8803166349975510642
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64394767353640818}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8358875054923723014}
+  - {fileID: 486432109242871421}
+  - {fileID: 726923652204443056}
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!320 &5945278182731388996
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64394767353640818}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: c290e3061ad14324fa74857440fe2b72, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 2
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: 2278793005745870680, guid: c290e3061ad14324fa74857440fe2b72, type: 2}
+    value: {fileID: 2645143501227828926}
+  - key: {fileID: -6476216151820219361, guid: c290e3061ad14324fa74857440fe2b72, type: 2}
+    value: {fileID: 2888445859104097589}
+  - key: {fileID: 3110738062455287314, guid: c290e3061ad14324fa74857440fe2b72, type: 2}
+    value: {fileID: 7991837000509727365}
+  - key: {fileID: 8239724763879458085, guid: c290e3061ad14324fa74857440fe2b72, type: 2}
+    value: {fileID: 0}
+  m_ExposedReferences:
+    m_References: []
+--- !u!1 &149354677028706029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5027669424125411736}
+  m_Layer: 5
+  m_Name: LevelUpVFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5027669424125411736
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 149354677028706029}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5179485745476692466}
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &671078855729100258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5935467899147468181}
+  - component: {fileID: 5802392648913694600}
+  - component: {fileID: 542417076384505733}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5935467899147468181
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671078855729100258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 700}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &5802392648913694600
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671078855729100258}
+  m_CullTransparentMesh: 1
+--- !u!114 &542417076384505733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671078855729100258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &963875474402424428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6094997035783538295}
+  - component: {fileID: 7493147067659788235}
+  - component: {fileID: 4272923931159481549}
+  m_Layer: 5
+  m_Name: Image (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6094997035783538295
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963875474402424428}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4862190541493908623}
+  - {fileID: 8023177716399734990}
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &7493147067659788235
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963875474402424428}
+  m_CullTransparentMesh: 1
+--- !u!114 &4272923931159481549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963875474402424428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1150862283287196042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5179485745476692466}
+  - component: {fileID: 2314122339821058473}
+  - component: {fileID: 1273910693756478776}
+  - component: {fileID: 246311798122101683}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5179485745476692466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150862283287196042}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5027669424125411736}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2314122339821058473
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150862283287196042}
+  m_CullTransparentMesh: 1
+--- !u!114 &1273910693756478776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150862283287196042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 2100000, guid: 873e8f970c538874892a2d23bcb5d177, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.02745098}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1533881717996628992, guid: 97a41fc3859a2cb4bb2e7695893ff3fc, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &246311798122101683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150862283287196042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &1489313646038588635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7665496935962836201}
+  - component: {fileID: 5393477269381023172}
+  - component: {fileID: 5304958568377638360}
+  m_Layer: 5
+  m_Name: Image (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7665496935962836201
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1489313646038588635}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2122551100677089529}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5393477269381023172
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1489313646038588635}
+  m_CullTransparentMesh: 1
+--- !u!114 &5304958568377638360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1489313646038588635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2337764775459272568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5598627901497714788}
+  - component: {fileID: 5315233283040079541}
+  - component: {fileID: 3031445348427586005}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5598627901497714788
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337764775459272568}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6261428170776716103}
+  - {fileID: 3306934030240007849}
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -600, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &5315233283040079541
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337764775459272568}
+  m_CullTransparentMesh: 1
+--- !u!114 &3031445348427586005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337764775459272568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2457430659824835108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9176060536408910360}
+  - component: {fileID: 1202339236332976993}
+  - component: {fileID: 711670306336789905}
+  - component: {fileID: 1310333870540387233}
+  - component: {fileID: 8156399414737948903}
+  m_Layer: 5
+  m_Name: LevelUPUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9176060536408910360
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2457430659824835108}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 865695257110206384}
+  - {fileID: 5027669424125411736}
+  - {fileID: 8803166349975510642}
+  - {fileID: 5598627901497714788}
+  - {fileID: 6094997035783538295}
+  - {fileID: 2122551100677089529}
+  - {fileID: 5935467899147468181}
+  - {fileID: 4642553082119351249}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1202339236332976993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2457430659824835108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b74d5841363ecaa45a3a266a72b31492, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _showAnimation: {fileID: 5945278182731388996}
+  _hideAnimation: {fileID: 711670306336789905}
+--- !u!320 &711670306336789905
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2457430659824835108}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 2
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: 81880181354420398, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 1310333870540387233}
+  - key: {fileID: -342381758878110273, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 8156399414737948903}
+  - key: {fileID: 6586017452033887158, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: -2701199579822556528, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 2645143501227828926}
+  - key: {fileID: -8157295392869283734, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 2888445859104097589}
+  - key: {fileID: -2260789298814534584, guid: ff946684f973fa640bf4f7b46cb742a4, type: 2}
+    value: {fileID: 7991837000509727365}
+  m_ExposedReferences:
+    m_References: []
+--- !u!95 &1310333870540387233
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2457430659824835108}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &8156399414737948903
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2457430659824835108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e52de21a22b6dd44c9cc19f810c65059, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.SignalReceiver
+  m_Events:
+    m_Signals:
+    - {fileID: 11400000, guid: 396129191f1775e43bd473cece8930f9, type: 2}
+    m_Events:
+    - m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_TargetAssemblyTypeName: InGameUIController, Assembly-CSharp
+          m_MethodName: CloseLevelupUI
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!1 &2483816088511478609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4862190541493908623}
+  - component: {fileID: 4059663856064322668}
+  - component: {fileID: 3172158474535184912}
+  m_Layer: 5
+  m_Name: Image (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4862190541493908623
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483816088511478609}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6094997035783538295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4059663856064322668
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483816088511478609}
+  m_CullTransparentMesh: 1
+--- !u!114 &3172158474535184912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483816088511478609}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5332697268633554163
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 865695257110206384}
+  - component: {fileID: 3266191527148320878}
+  - component: {fileID: 38853692326000716}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &865695257110206384
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5332697268633554163}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3266191527148320878
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5332697268633554163}
+  m_CullTransparentMesh: 1
+--- !u!114 &38853692326000716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5332697268633554163}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9372549}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6956053926216688738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3306934030240007849}
+  - component: {fileID: 7945608429484747034}
+  - component: {fileID: 5914255312963996986}
+  m_Layer: 5
+  m_Name: Image (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3306934030240007849
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6956053926216688738}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5598627901497714788}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7945608429484747034
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6956053926216688738}
+  m_CullTransparentMesh: 1
+--- !u!114 &5914255312963996986
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6956053926216688738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7461539753683251017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4642553082119351249}
+  - component: {fileID: 5487098017761357049}
+  - component: {fileID: 7593521712102946269}
+  m_Layer: 5
+  m_Name: Image (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4642553082119351249
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7461539753683251017}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 700}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &5487098017761357049
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7461539753683251017}
+  m_CullTransparentMesh: 1
+--- !u!114 &7593521712102946269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7461539753683251017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7756347118175216191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8023177716399734990}
+  - component: {fileID: 1161321650335984453}
+  - component: {fileID: 8729349265100328818}
+  m_Layer: 5
+  m_Name: Image (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8023177716399734990
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7756347118175216191}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6094997035783538295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1161321650335984453
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7756347118175216191}
+  m_CullTransparentMesh: 1
+--- !u!114 &8729349265100328818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7756347118175216191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7837143017886145491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2122551100677089529}
+  - component: {fileID: 22092568901740810}
+  - component: {fileID: 3663849556553339456}
+  m_Layer: 5
+  m_Name: Image (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2122551100677089529
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7837143017886145491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1090641438570014890}
+  - {fileID: 7665496935962836201}
+  m_Father: {fileID: 9176060536408910360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 600, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &22092568901740810
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7837143017886145491}
+  m_CullTransparentMesh: 1
+--- !u!114 &3663849556553339456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7837143017886145491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8286836260875681535
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1090641438570014890}
+  - component: {fileID: 6246986150192134433}
+  - component: {fileID: 2603120434606249000}
+  m_Layer: 5
+  m_Name: Image (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1090641438570014890
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8286836260875681535}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2122551100677089529}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6246986150192134433
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8286836260875681535}
+  m_CullTransparentMesh: 1
+--- !u!114 &2603120434606249000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8286836260875681535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8690570034902980742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6261428170776716103}
+  - component: {fileID: 1271508449641261928}
+  - component: {fileID: 4872916341904367536}
+  m_Layer: 5
+  m_Name: Image (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6261428170776716103
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690570034902980742}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5598627901497714788}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 100, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1271508449641261928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690570034902980742}
+  m_CullTransparentMesh: 1
+--- !u!114 &4872916341904367536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690570034902980742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7142518519572273488, guid: c2de13832c2246c42a385bc3219dc28e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &2914589010270101264
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8803166349975510642}
+    m_Modifications:
+    - target: {fileID: 436971374460970977, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1829967351241692349, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: a13af1f972bd00f4d95f30226d286ce7, type: 2}
+    - target: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: SelectItemBtn1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1202339236332976993}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayHideAnimation
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: LevelUPUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 451
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -600
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Type
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_FillAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_FillMethod
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847427162872757107, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: a13af1f972bd00f4d95f30226d286ce7, type: 2}
+    - target: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2645143501227828926}
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8268123527895823883}
+    - targetCorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7769417779000708411}
+    - targetCorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3515571910414580462}
+  m_SourcePrefab: {fileID: 100100000, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+--- !u!1 &2024616827987771456 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 2914589010270101264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &2645143501227828926
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024616827987771456}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &8268123527895823883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024616827987771456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32fd92833e03c204baeeabce25c94df1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _selectedImage: {fileID: 6131704648941178927}
+--- !u!1 &3375928923161697157 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 2914589010270101264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3515571910414580462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3375928923161697157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &5743672235961384761 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 2914589010270101264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7769417779000708411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5743672235961384761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &6131704648941178927 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 2914589010270101264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8358875054923723014 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 2914589010270101264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6225257701976021926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8803166349975510642}
+    m_Modifications:
+    - target: {fileID: 935398941806252815, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemLevel3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: SelectItemBtn3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1202339236332976993}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayHideAnimation
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: LevelUPUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 451
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7509633032859078092, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemDescription3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8630604459479720153, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemName3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9048846546615383759, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemImage3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7991837000509727365}
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2211710682329546955}
+    - targetCorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3851207282244708282}
+    - targetCorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4986177461543488648}
+  m_SourcePrefab: {fileID: 100100000, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+--- !u!224 &726923652204443056 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6225257701976021926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3102431772791772313 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6225257701976021926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3576881548468943759 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6225257701976021926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3851207282244708282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3576881548468943759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &5823023332607827763 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6225257701976021926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4986177461543488648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5823023332607827763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &7065831025546282230 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6225257701976021926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &7991837000509727365
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7065831025546282230}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &2211710682329546955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7065831025546282230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32fd92833e03c204baeeabce25c94df1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpBtn
+  _selectedImage: {fileID: 3102431772791772313}
+--- !u!1001 &6535326405233852523
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8803166349975510642}
+    m_Modifications:
+    - target: {fileID: 935398941806252815, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemLevel2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: SelectItemBtn2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1202339236332976993}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayHideAnimation
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: LevelUPUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3943537998022678240, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 451
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7509633032859078092, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemDescription2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402161544962796403, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8630604459479720153, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemName2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9048846546615383759, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      propertyPath: m_Name
+      value: ItemImage2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2888445859104097589}
+    - targetCorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3131565309299560558}
+    - targetCorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7491029520151965138}
+    - targetCorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1768995258353263389}
+  m_SourcePrefab: {fileID: 100100000, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+--- !u!224 &486432109242871421 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6661390992835489302, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6535326405233852523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2871228493895159636 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9037180356170092351, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6535326405233852523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4428455197229555778 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7477994310766977065, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6535326405233852523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7491029520151965138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4428455197229555778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &6636373486042137854 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 480484636312274069, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6535326405233852523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1768995258353263389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6636373486042137854}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d90cfdcde5fd14a8622dc7f831ce40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnScaledTimeWrapper
+--- !u!1 &7987263378217541435 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
+  m_PrefabInstance: {fileID: 6535326405233852523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &2888445859104097589
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7987263378217541435}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &3131565309299560558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7987263378217541435}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32fd92833e03c204baeeabce25c94df1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpBtn
+  _selectedImage: {fileID: 2871228493895159636}

--- a/Assets/04.Scripts/Passive/LevelUPUI.prefab.meta
+++ b/Assets/04.Scripts/Passive/LevelUPUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 44c77088d11244a479938a040100b9dc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Passive/Passive.cs
+++ b/Assets/04.Scripts/Passive/Passive.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+public enum Passive
+{
+    Heart,          // 최대 HP 증가
+    Nuclear,        // 공격력 증가
+    Shield,         // 방어력 증가
+    Repair,         // 회복력 강화
+    Speed,          // 이동 속도 증가
+    Luck,           // 행운 증가 (치명타, 드랍률)
+    EXP,            // 경험치 획득량 증가
+    Magnet,         // 수집 범위 증가
+    AgitHP,         // 아지트 HP 증가
+    AgitDef,        // 아지트 방어력 증가
+    AgitArea,       // 아지트 영역 확장
+    TurretDmg       // 포탑 공격력 증가
+}
+
+[CreateAssetMenu(fileName = "New Passive Data", menuName = "Game Data/Passive Item")]
+public class LevelUpPassive : ScriptableObject
+{
+    [Header("Basic Info")]
+    public string itemName;
+    public Sprite icon;
+    [TextArea] public string descriptionDesc;
+
+    [Header("Stats")]
+    public Passive passive;
+    public int maxLevel = 5;
+
+    public float[] valuePerLevel;
+    public float[] valuePerLevel2;
+
+    public string GetDescription(int nextLevel)
+    {
+        if (nextLevel > maxLevel) return "Max Level";
+
+        float val1 = valuePerLevel.Length >= nextLevel ? valuePerLevel[nextLevel - 1] : 0;
+        float val2 = valuePerLevel2.Length >= nextLevel ? valuePerLevel2[nextLevel - 1] : 0;
+
+        return string.Format(descriptionDesc, val1, val2);
+    }
+}

--- a/Assets/04.Scripts/Passive/Passive.cs.meta
+++ b/Assets/04.Scripts/Passive/Passive.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d3b4e24c8ec88c44a1b32d7f481e474

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -27,7 +27,7 @@ public class PlayerLevelControl : MonoBehaviour
     public void AddXP(float amount)
     {
         currentXP += amount;
-        Debug.Log($"����ġ {amount} ȹ�� (����: {currentXP} / {requiredXP})");
+        Debug.Log($"경험치 {amount} 휙득 (현재: {currentXP} / {requiredXP})");
 
         while (currentXP >= requiredXP)
         {
@@ -41,17 +41,8 @@ public class PlayerLevelControl : MonoBehaviour
         currentLevel++;
         UpdateRequiredXP();
 
-        Debug.Log($"LEVEL UP! ���� ����: {currentLevel}");
-        /*
-        if (InGameManager.Instance != null)
-        {
-            InGameManager.Instance.OpenLevelUpUI();
-        }
-        else
-        {
-            Debug.LogError("InGameManager�� ���� �����ϴ�!");
-        }
-        */
+        Debug.Log($"LEVEL UP! 현재 레벨 {currentLevel}");
+
         OnLevelUp?.Invoke(currentLevel);
     }
 

--- a/Assets/04.Scripts/Player/PlayerMoveController.cs
+++ b/Assets/04.Scripts/Player/PlayerMoveController.cs
@@ -1,7 +1,3 @@
-/*
-이 스크립트는 플레이어 이동을 관리함
-플레이어 이동과 관련이 없는 스크립트는 이 코드에 작성하면 안된다.
-*/
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -3,56 +3,61 @@
 */
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Unity.Mathematics;
-using Unity.VisualScripting;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 public class PlayerStatController : MonoBehaviour, IDamageable
 {
     #region 스크립터블 오브젝트
     [Header("스크립터블 오브젝트들")]
-    [SerializeField]
-    private PlayerDefaultData playerDefaultData;
+    [SerializeField] private PlayerDefaultData playerDefaultData;
     #endregion
-    
+
     #region 플레이어 스탯 변수들
-    public int CurrentLevel {get; set;}
+    public Dictionary<Passive, int> passiveLevels = new Dictionary<Passive, int>();
+
+    public int CurrentLevel { get; set; }
     public int CurrentExp { get; private set; }
-    public int MaxHp {get; set;}
-    public int CurrentHp {get; set;}
-    public int Defense  {get; set;}
-    public int HpGenSpeed {get; set;}
-    public float MoveSpeed {get; set;}
-    public float ItemGetRadius {get; set;}
-    public float Luck {get; set;}
-    public float Growth {get; set;}
-    public float Greed {get; set;}
-    public float Curse {get; set;}
-    public int Life {get; set;}
-    public bool Dead {get; set;}
-    public int WeaponSlotSize{get; set;}
-    public int PassiveItemSlotSize{get; set;}
-    public int TurretSlotSize {get; set;}
+    public int MaxHp { get; set; }
+    public int CurrentHp { get; set; }
+    public int Defense { get; set; }
+    public int HpGenSpeed { get; set; }
+
+    public float DamageMultiplier { get; set; } = 1.0f;
+    public float CriticalPercent { get; set; } = 0f;
+
+    public float MoveSpeed { get; set; }
+    public float ItemGetRadius { get; set; }
+    public float Luck { get; set; }
+    public float Growth { get; set; }
+    public float Greed { get; set; }
+    public float Curse { get; set; }
+    public int Life { get; set; }
+    public bool Dead { get; set; }
+
+    public int WeaponSlotSize { get; set; }
+    public int PassiveItemSlotSize { get; set; }
+    public int TurretSlotSize { get; set; }
+
+    public float AgitHp { get; set; }
+    public float AgitDef { get; set; }
+    public int AgitArea { get; set; }
+    public float TurretDmg { get; set; }
     #endregion
 
     #region 플레이어 부활 시간 관련 변수
-    [SerializeField]
-    private float _reviveDelayTime = 1.5f;
+    [SerializeField] private float _reviveDelayTime = 1.5f;
     private float ReviveDelayTime
     {
         get => _reviveDelayTime;
         set => _reviveDelayTime = (value <= 0) ? 0 : value;
     }
-    
     private WaitForSeconds _reviveDelayAction;
     #endregion
-    
-    #region 스크립트 참조변수
-    private PlayerEventController _playerEventController;
-    #endregion
 
-    # region 유니티 생명주기 함수들
+    private PlayerEventController _playerEventController;
+
     private void OnEnable()
     {
         if (_playerEventController != null)
@@ -69,92 +74,178 @@ public class PlayerStatController : MonoBehaviour, IDamageable
 
     public void SetUp()
     {
+        if (PlayerManager.Instance != null)
+        {
+            _playerEventController = PlayerManager.Instance.PlayerEventController;
+        }
         resetPlayerStat();
-        _playerEventController = PlayerManager.Instance.PlayerEventController;
         _reviveDelayAction = new WaitForSeconds(ReviveDelayTime);
     }
-    #endregion
-    
-    #region 이벤트 관련 메서드
+
     private void AddToEvent()
     {
+        if (_playerEventController == null) return;
         _playerEventController.Death += AddToDeath;
         _playerEventController.Revive += AddToRevive;
     }
-    
+
     private void RemoveFromEvent()
     {
+        if (_playerEventController == null) return;
         _playerEventController.Death -= AddToDeath;
         _playerEventController.Revive -= AddToRevive;
     }
 
     private void AddToDeath()
     {
-        Debug.Log("플레이어 사망");
-        PlayerManager.Instance.PlayerMoveController.InputVector = Vector2.zero;
+        if (PlayerManager.Instance.PlayerMoveController != null)
+        {
+            PlayerManager.Instance.PlayerMoveController.InputVector = Vector2.zero;
+        }
         Dead = true;
         StartCoroutine(AfterDead());
     }
-    
+
     private void AddToRevive()
     {
-        Debug.Log("플레이어 부활");
         CurrentHp = MaxHp;
         Life = Math.Max(0, Life - 1);
         Dead = false;
     }
-    #endregion
 
     private void resetPlayerStat()
     {
+        passiveLevels.Clear();
+
         CurrentLevel = playerDefaultData.DefaultLevel;
         MaxHp = playerDefaultData.DefaultMaxHP;
         CurrentHp = MaxHp;
         Defense = playerDefaultData.DefaultDef;
         HpGenSpeed = playerDefaultData.DefaultHpGenSpeed;
-        MoveSpeed= playerDefaultData.DefaultSpeed;
+        MoveSpeed = playerDefaultData.DefaultSpeed;
         ItemGetRadius = playerDefaultData.DefaultReceiveRadius;
         Luck = playerDefaultData.DefaultLuck;
         Growth = playerDefaultData.DefaultGrowth;
         Greed = playerDefaultData.DefaultGreed;
         Curse = playerDefaultData.DefaultCurse;
         Life = playerDefaultData.DefaultLife;
-        
+
+        DamageMultiplier = 1.0f;
+        CriticalPercent = 0f;
+
+        AgitHp = 0f;
+        AgitDef = 0f;
+        AgitArea = 0;
+        TurretDmg = 0f;
+
         WeaponSlotSize = playerDefaultData.DefaultWeaponSlotSize;
         PassiveItemSlotSize = playerDefaultData.DefaultPassiveItemSlotSize;
         TurretSlotSize = playerDefaultData.DefaultTurretSlotSize;
     }
-    
-    #region 플레이어 데미지 관련 메서드
-    // 플레이어의 hp를 치료하는 효과는 다른 함수로 구현하도록 한다.
+
+    public int GetCurrentPassiveLevel(Passive type)
+    {
+        return passiveLevels.ContainsKey(type) ? passiveLevels[type] : 0;
+    }
+
+    public void LevelUpPassiveStat(LevelUpPassive data)
+    {
+        if (!passiveLevels.ContainsKey(data.passive))
+        {
+            passiveLevels[data.passive] = 1;
+        }
+        else
+        {
+            passiveLevels[data.passive]++;
+        }
+
+        int currentLevel = passiveLevels[data.passive];
+
+        float val1 = (data.valuePerLevel != null && data.valuePerLevel.Length >= currentLevel) ? data.valuePerLevel[currentLevel - 1] : 0;
+        float val2 = (data.valuePerLevel2 != null && data.valuePerLevel2.Length >= currentLevel) ? data.valuePerLevel2[currentLevel - 1] : 0;
+
+        ApplyStat(data.passive, val1, val2);
+
+        Debug.Log($"[패시브 업그레이드] {data.itemName} Lv.{currentLevel} 달성! " +
+                  $"(공격력 배율: {DamageMultiplier} / 방어력: {Defense} / 최대체력: {MaxHp})");
+    }
+
+    private void ApplyStat(Passive type, float val1, float val2)
+    {
+        switch (type)
+        {
+            case Passive.Heart:
+                int prevMaxHp = MaxHp;
+                MaxHp = playerDefaultData.DefaultMaxHP + (int)val1;
+                CurrentHp += (MaxHp - prevMaxHp);
+                break;
+            case Passive.Nuclear:
+                DamageMultiplier = 1.0f + (val1 / 100f);
+                break;
+            case Passive.Shield:
+                Defense = playerDefaultData.DefaultDef + (int)val1;
+                break;
+            case Passive.Repair:
+                HpGenSpeed = playerDefaultData.DefaultHpGenSpeed + (int)val1;
+                break;
+            case Passive.Speed:
+                MoveSpeed = playerDefaultData.DefaultSpeed * (1.0f + val1);
+                break;
+            case Passive.Luck:
+                CriticalPercent = val1;
+                Luck = playerDefaultData.DefaultLuck + val2;
+                break;
+            case Passive.EXP:
+                Growth = playerDefaultData.DefaultGrowth + val1;
+                break;
+            case Passive.Magnet:
+                ItemGetRadius = playerDefaultData.DefaultReceiveRadius * (1.0f + val1);
+                break;
+            case Passive.AgitHP:
+                AgitHp = val1;
+                break;
+            case Passive.AgitDef:
+                AgitDef = val1;
+                break;
+            case Passive.AgitArea:
+                AgitArea = (int)val1;
+                break;
+            case Passive.TurretDmg:
+                TurretDmg = val1;
+                break;
+        }
+    }
+
     public void TakeDamage(int damage)
     {
         if (Dead == true) return;
 
-        _playerEventController.CallHurt();
-        
+        if (_playerEventController != null)
+            _playerEventController.CallHurt();
+
         int calcDmg = CalculateReducedDmg(damage, Defense);
         CurrentHp -= calcDmg;
-        Debug.Log($"{calcDmg} 적용, 남은 체력: {CurrentHp}");
 
         if (CurrentHp <= 0)
         {
             CurrentHp = 0;
-            _playerEventController.CallDeath();
+            if (_playerEventController != null)
+                _playerEventController.CallDeath();
         }
     }
-    private int CalculateReducedDmg(int damage, int defense)
+
+    int CalculateReducedDmg(int damage, int defense)
     {
-        float value = damage * 100 / (100 + defense);
+        float value = damage * 100.0f / (100.0f + defense);
         return (int)Math.Round(value);
     }
-    #endregion
-    
-    #region 플레이어 사망 관련 메서드
+
     private IEnumerator AfterDead()
     {
         yield return _reviveDelayAction;
-        if (Life > 0) _playerEventController.CallRevive();
+        if (Life > 0 && _playerEventController != null)
+        {
+            _playerEventController.CallRevive();
+        }
     }
-    #endregion
 }

--- a/Assets/04.Scripts/UI/InGame/InGameManager.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameManager.cs
@@ -26,8 +26,12 @@ public class InGameManager : SingletonBehaviour<InGameManager>
         }
 
         PlayTime = 0;
-        AudioManager.Instance.StopAll();
-        AudioManager.Instance.Play(AudioType.BGM, "InGameBGM");
+
+        if (AudioManager.Instance != null)
+        {
+            AudioManager.Instance.StopAll();
+            AudioManager.Instance.Play(AudioType.BGM, "InGameBGM");
+        }
 
         _playerLevelControl = FindAnyObjectByType<PlayerLevelControl>();
         if (_playerLevelControl != null)
@@ -59,7 +63,7 @@ public class InGameManager : SingletonBehaviour<InGameManager>
     {
         if (InGameUIController != null)
         {
-            InGameUIController.OpenLevelupUI();
+            InGameUIController.OpenLevelupUI(level);
         }
         else
         {

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -41,14 +42,43 @@ public class InGameUIController : MonoBehaviour
 
     [SerializeField] private DamageTextSpawner _damageTextSpawner;
 
+    // ★ 새로운 랜덤 패시브 시스템을 위한 변수들
+    [Header("New Passive Data Pool")]
+    public List<LevelUpPassive> allPassives;
+
+    private PlayerStatController _playerStat;
+    private PlayerLevelControl _playerLevelControl;
+
     private void Awake()
     {
         Time.timeScale = 1f;
-        _pauseUI.SetActive(false);
-        _levelupUI.SetActive(false);
-        _endGameUI.SetActive(false);
-        _inGameUI.SetActive(true);
+
+        // ★ 빈 씬에서 에러가 나지 않도록 방어막(null 체크) 추가!
+        if (_pauseUI != null) _pauseUI.SetActive(false);
+        if (_levelupUI != null) _levelupUI.SetActive(false);
+        if (_endGameUI != null) _endGameUI.SetActive(false);
+        if (_inGameUI != null) _inGameUI.SetActive(true);
     }
+
+    private void Start()
+    {
+        _playerStat = FindAnyObjectByType<PlayerStatController>();
+        _playerLevelControl = FindAnyObjectByType<PlayerLevelControl>();
+
+        if (_playerLevelControl != null)
+        {
+            _playerLevelControl.OnLevelUp += OpenLevelupUI; // 종소리 구독
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (_playerLevelControl != null)
+        {
+            _playerLevelControl.OnLevelUp -= OpenLevelupUI;
+        }
+    }
+
     private void Update()
     {
         HandleInput();
@@ -59,14 +89,18 @@ public class InGameUIController : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.Escape))
         {
-            //AudioManager.Instance.Play();
-
-            var frontUI = UIManager.Instance.GetFrontUI();
-            if (frontUI != null)
+            // 테스트 씬에 UIManager가 없을 경우를 대비한 안전장치
+            if (UIManager.Instance != null)
             {
-                frontUI.OnClickCloseButton();
+                var frontUI = UIManager.Instance.GetFrontUI();
+                if (frontUI != null)
+                {
+                    frontUI.OnClickCloseButton();
+                    return;
+                }
             }
-            else if (_pauseUI.activeSelf == true)
+
+            if (_pauseUI != null && _pauseUI.activeSelf == true)
             {
                 _pauseUI.SetActive(false);
                 Time.timeScale = 1f;
@@ -81,47 +115,37 @@ public class InGameUIController : MonoBehaviour
     private void ShowQuitConfirmUI()
     {
         Application.Quit();
-        /*var data = new ConfirmUIData()
-        {
-            ConfirmType = 
-             TitleText = 
-            DescriptionText =
-            OkButtonText = 
-            CancleButtonText = 
-            ActionOnClickOkButton = () => Application.Quit()
-        };
-        UIManager.Instance.OpenUI<ConfirmUI>(data);*/
     }
 
     public void OnClickOpenPauseUI()
     {
-        _pauseUI.SetActive(true);
-        AudioManager.Instance.Play(AudioType.SFX, "Button_Click");
+        if (_pauseUI != null) _pauseUI.SetActive(true);
+        if (AudioManager.Instance != null) AudioManager.Instance.Play(AudioType.SFX, "Button_Click");
         Time.timeScale = 0f;
     }
-    
+
     public void OnClickClosePauseUI()
     {
-        _pauseUI.SetActive(false);
-        AudioManager.Instance.Play(AudioType.SFX, "Button_Click_Close");
+        if (_pauseUI != null) _pauseUI.SetActive(false);
+        if (AudioManager.Instance != null) AudioManager.Instance.Play(AudioType.SFX, "Button_Click_Close");
         Time.timeScale = 1f;
     }
 
     public void OnClickOpenConfigUI()
     {
-        AudioManager.Instance.Play(AudioType.SFX, "Button_Click");
-        UIManager.Instance.OpenUI<ConfigUI>();
+        if (AudioManager.Instance != null) AudioManager.Instance.Play(AudioType.SFX, "Button_Click");
+        if (UIManager.Instance != null) UIManager.Instance.OpenUI<ConfigUI>();
     }
 
     public void OnClickRestartGame()
     {
-        SceneLoader.Instance.LoadScene(ESceneType.InGame);
+        if (SceneLoader.Instance != null) SceneLoader.Instance.LoadScene(ESceneType.InGame);
     }
 
     public void OnClickGoLobby()
     {
-        AudioManager.Instance.Play(AudioType.SFX, "Button_Click_Close");
-        SceneLoader.Instance.LoadScene(ESceneType.Lobby);
+        if (AudioManager.Instance != null) AudioManager.Instance.Play(AudioType.SFX, "Button_Click_Close");
+        if (SceneLoader.Instance != null) SceneLoader.Instance.LoadScene(ESceneType.Lobby);
     }
 
     public void OnClickExitGame()
@@ -129,26 +153,90 @@ public class InGameUIController : MonoBehaviour
         Application.Quit();
     }
 
-    public void OpenLevelupUI()
+    public void OpenLevelupUI(int level)
     {
-        _levelupUI.SetActive(true);
-        UpdateSelectableItemInUI();
+        if (_levelupUI != null) _levelupUI.SetActive(true);
+        ShowRandomPassives();
         Time.timeScale = 0f;
     }
 
     public void CloseLevelupUI()
     {
-        _levelupUI.SetActive(false);
+        if (_levelupUI != null) _levelupUI.SetActive(false);
         Time.timeScale = 1f;
+    }
+
+    // ★ 랜덤 패시브를 띄워주는 핵심 로직
+    private void ShowRandomPassives()
+    {
+        if (_playerStat == null || allPassives == null) return;
+
+        List<LevelUpPassive> availablePassives = new List<LevelUpPassive>();
+
+        foreach (var p in allPassives)
+        {
+            if (p == null) continue;
+            int currentLevel = _playerStat.GetCurrentPassiveLevel(p.passive);
+            if (currentLevel < p.maxLevel)
+            {
+                availablePassives.Add(p);
+            }
+        }
+
+        availablePassives = availablePassives.OrderBy(x => UnityEngine.Random.value).ToList();
+
+        for (int i = 0; i < _itemSelectBtns.Length; i++)
+        {
+            if (_itemSelectBtns[i] == null) continue;
+
+            if (i < availablePassives.Count)
+            {
+                _itemSelectBtns[i].gameObject.SetActive(true);
+
+                LevelUpPassive selectedData = availablePassives[i];
+                int nextLevel = _playerStat.GetCurrentPassiveLevel(selectedData.passive) + 1;
+
+                // UI 연결이 하나라도 빠져있어도 기절하지 않도록 방어 코드 추가
+                if (_itemSelectBtnDatas.Length > i)
+                {
+                    if (_itemSelectBtnDatas[i].ItemImage != null)
+                    {
+                        _itemSelectBtnDatas[i].ItemImage.sprite = selectedData.icon;
+                        _itemSelectBtnDatas[i].ItemImage.color = Color.white;
+                    }
+                    if (_itemSelectBtnDatas[i].ItemNameText != null)
+                        _itemSelectBtnDatas[i].ItemNameText.text = selectedData.itemName;
+                    if (_itemSelectBtnDatas[i].ItemDescriptionText != null)
+                        _itemSelectBtnDatas[i].ItemDescriptionText.text = selectedData.GetDescription(nextLevel);
+                    if (_itemSelectBtnDatas[i].ItemLevelText != null)
+                        _itemSelectBtnDatas[i].ItemLevelText.text = (nextLevel == 1) ? "New!" : $"Lv.{nextLevel}";
+                }
+
+                _itemSelectBtns[i].onClick.RemoveAllListeners();
+                _itemSelectBtns[i].onClick.AddListener(() => OnPassiveSelected(selectedData));
+            }
+            else
+            {
+                _itemSelectBtns[i].gameObject.SetActive(false);
+            }
+        }
+    }
+
+    private void OnPassiveSelected(LevelUpPassive data)
+    {
+        if (_playerStat != null) _playerStat.LevelUpPassiveStat(data);
+        CloseLevelupUI();
     }
 
     public void OpenEndgameUI()
     {
-        _endGameUI.SetActive(true);
+        if (_endGameUI != null) _endGameUI.SetActive(true);
     }
 
     public void ShowPlayTime()
     {
+        if (InGameManager.Instance == null || _playTimeUI == null) return;
+
         float time = InGameManager.Instance.PlayTime;
         string min = ((int)(time / 60)).ToString("D2");
         string sec = ((int)(time % 60)).ToString("D2");
@@ -156,14 +244,18 @@ public class InGameUIController : MonoBehaviour
         _playTimeUI.text = $"{min} : {sec}";
     }
 
+    // ★ 빈 씬에서 제일 에러가 많이 나던 경험치 바 함수 완벽 방어
     public void UpdateExpBar()
     {
+        if (_expBar == null || DataTableManager.Instance == null || PlayerManager.Instance == null) return;
+
         int currentLevel = PlayerManager.Instance.PlayerStatController.CurrentLevel;
         float currentExp = PlayerManager.Instance.PlayerStatController.CurrentExp;
         float maxExp = DataTableManager.Instance.GetGameData<ExpData>().GetExpData(currentLevel);
         _expBar.fillAmount = currentExp / maxExp;
     }
 
+    // ---- [이하 기존 아이템/미니맵 관련 코드들도 안전하게 방어막 추가] ----
     private void UpdateSelectableItemInUI()
     {
         UpdateSelectableItemBtn<WeaponStatData>(0);
@@ -173,18 +265,27 @@ public class InGameUIController : MonoBehaviour
 
     private void UpdateSelectableItemBtn<T>(int index) where T : IItemStatData
     {
+        if (DataTableManager.Instance == null) return;
+
         T newItemData = DataTableManager.Instance.GetSelectableItem<T>();
         if (EqualityComparer<T>.Default.Equals(newItemData, default(T)))
         {
-            Debug.Log("No Selectable Item.");
-            _itemSelectBtnDatas[index].ItemNameText.text = "";
-            _itemSelectBtnDatas[index].ItemImage.sprite = null;
-            _itemSelectBtnDatas[index].ItemImage.color = new Color(1, 1, 1, 0);
-            _itemSelectBtnDatas[index].ItemLevelText.text = "";
-            _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
-            _itemSelectBtns[index].onClick.RemoveAllListeners();
+            if (_itemSelectBtnDatas.Length > index)
+            {
+                if (_itemSelectBtnDatas[index].ItemNameText != null) _itemSelectBtnDatas[index].ItemNameText.text = "";
+                if (_itemSelectBtnDatas[index].ItemImage != null)
+                {
+                    _itemSelectBtnDatas[index].ItemImage.sprite = null;
+                    _itemSelectBtnDatas[index].ItemImage.color = new Color(1, 1, 1, 0);
+                }
+                if (_itemSelectBtnDatas[index].ItemLevelText != null) _itemSelectBtnDatas[index].ItemLevelText.text = "";
+                if (_itemSelectBtnDatas[index].ItemDescriptionText != null) _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
+            }
+            if (_itemSelectBtns.Length > index && _itemSelectBtns[index] != null) _itemSelectBtns[index].onClick.RemoveAllListeners();
             return;
         }
+
+        if (PlayerManager.Instance == null) return;
         int currentItemLevel = PlayerManager.Instance.PlayerItemController.GetItemLevelInSlot<T>(newItemData);
 
         int ItemLevel = 1;
@@ -192,74 +293,64 @@ public class InGameUIController : MonoBehaviour
         {
             ItemLevel = currentItemLevel + 1;
         }
-        _itemSelectBtnDatas[index].ItemNameText.text = newItemData.GetName();
-        _itemSelectBtnDatas[index].ItemImage.sprite = newItemData.GetIcon();
-        _itemSelectBtnDatas[index].ItemLevelText.text = ItemLevel.ToString();
-        _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
-        _itemSelectBtns[index].onClick.RemoveAllListeners();
-        _itemSelectBtns[index].onClick.AddListener(() => OnClickItemSelectBtn<T>(newItemData));
+
+        if (_itemSelectBtnDatas.Length > index)
+        {
+            if (_itemSelectBtnDatas[index].ItemNameText != null) _itemSelectBtnDatas[index].ItemNameText.text = newItemData.GetName();
+            if (_itemSelectBtnDatas[index].ItemImage != null) _itemSelectBtnDatas[index].ItemImage.sprite = newItemData.GetIcon();
+            if (_itemSelectBtnDatas[index].ItemLevelText != null) _itemSelectBtnDatas[index].ItemLevelText.text = ItemLevel.ToString();
+            if (_itemSelectBtnDatas[index].ItemDescriptionText != null) _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
+        }
+
+        if (_itemSelectBtns.Length > index && _itemSelectBtns[index] != null)
+        {
+            _itemSelectBtns[index].onClick.RemoveAllListeners();
+            _itemSelectBtns[index].onClick.AddListener(() => OnClickItemSelectBtn<T>(newItemData));
+        }
     }
 
     private void UpdateInventory()
     {
         foreach (var inventory in _inventories)
         {
-            inventory.UpdateSlot();
+            if (inventory != null) inventory.UpdateSlot();
         }
     }
+
     private void OnClickItemSelectBtn<T>(T newItemData) where T : IItemStatData
     {
-        PlayerManager.Instance.PlayerItemController.AddItemToSlot<T>(newItemData);
-        UpdateInventory();
+        if (PlayerManager.Instance != null)
+        {
+            PlayerManager.Instance.PlayerItemController.AddItemToSlot<T>(newItemData);
+            UpdateInventory();
+        }
     }
 
     public void ShowDamageText(Vector3 position, float damage)
     {
-        if (_damageTextSpawner == null)
-        {
-            Debug.Log("No DamageTextSpanwer.");
-            return;
-        }
-        _damageTextSpawner.ShowDamageText(damage, position);
+        if (_damageTextSpawner != null) _damageTextSpawner.ShowDamageText(damage, position);
     }
 
-    public void AddTracedEnemyInMinimap(Transform transform)
-    {
-        _minimap.AddTracedEnemy(transform);
-    }
-
-    public void RemoveTracedEnemyInMinimap(Transform transform)
-    {
-        _minimap.RemoveTracedEnemy(transform);
-    }
-
-    public void ShowMinimapWarning()
-    {
-        _minimap.PlayWarningAnim();
-    }
-
-    public void HideMinimapWarning()
-    {
-        _minimap.StopWarningAnim();
-    }
+    public void AddTracedEnemyInMinimap(Transform transform) { if (_minimap != null) _minimap.AddTracedEnemy(transform); }
+    public void RemoveTracedEnemyInMinimap(Transform transform) { if (_minimap != null) _minimap.RemoveTracedEnemy(transform); }
+    public void ShowMinimapWarning() { if (_minimap != null) _minimap.PlayWarningAnim(); }
+    public void HideMinimapWarning() { if (_minimap != null) _minimap.StopWarningAnim(); }
 
     public void ShowHealthLessWarning()
     {
-        if (_inGameVolume.profile.TryGet<Vignette>(out var vignette))
-            vignette.intensity.value = 1;
+        if (_inGameVolume != null && _inGameVolume.profile.TryGet<Vignette>(out var vignette)) vignette.intensity.value = 1;
     }
 
     public void HideHealthLessWarning()
     {
-        if (_inGameVolume.profile.TryGet<Vignette>(out var vignette))
-            vignette.intensity.value = 0;
+        if (_inGameVolume != null && _inGameVolume.profile.TryGet<Vignette>(out var vignette)) vignette.intensity.value = 0;
     }
 
     public void ShowEndGameUI()
     {
-        AudioManager.Instance.StopAll();
-        _inGameUI.SetActive(false);
-        _endGameUI.SetActive(true);
+        if (AudioManager.Instance != null) AudioManager.Instance.StopAll();
+        if (_inGameUI != null) _inGameUI.SetActive(false);
+        if (_endGameUI != null) _endGameUI.SetActive(true);
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
@@ -268,40 +359,28 @@ public class InGameUIController : MonoBehaviour
 
     public void ShowDamageTextDebug()
     {
-        if (_testEnemies == null)
-        {
-            Debug.Log("No testObj.");
-            return;
-        }
+        if (_testEnemies == null || _damageTextSpawner == null) return;
         foreach (var obj in _testEnemies)
         {
-            _damageTextSpawner.ShowDamageText(10110, obj.transform.position);
+            if (obj != null) _damageTextSpawner.ShowDamageText(10110, obj.transform.position);
         }
     }
 
     public void AddTracedEnemiesInMinimapDebug()
     {
-        if (_testEnemies == null)
-        {
-            Debug.Log("No testObj.");
-            return;
-        }
+        if (_testEnemies == null || _minimap == null) return;
         foreach (var obj in _testEnemies)
         {
-            _minimap.AddTracedEnemy(obj.transform);
+            if (obj != null) _minimap.AddTracedEnemy(obj.transform);
         }
     }
 
     public void RemoveTracedEnemiesInMinimapDebug()
     {
-        if (_testEnemies == null)
-        {
-            Debug.Log("No testObj.");
-            return;
-        }
+        if (_testEnemies == null || _minimap == null) return;
         foreach (var obj in _testEnemies)
         {
-            _minimap.RemoveTracedEnemy(obj.transform);
+            if (obj != null) _minimap.RemoveTracedEnemy(obj.transform);
         }
     }
 #endif

--- a/Assets/Resources/Texture/0.mat
+++ b/Assets/Resources/Texture/0.mat
@@ -54,7 +54,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 33.547153
+    - _UnscaledTime: 60.948006
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _RepeatVector: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/buttonShine.mat
+++ b/Assets/Resources/Texture/buttonShine.mat
@@ -49,7 +49,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 55.84364
+    - _UnscaledTime: 60.948006
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _Color: {r: 0, g: 0, b: 0, a: 1}


### PR DESCRIPTION
# 📌개요
- 레벨업 시 패시브 업그레이드 UI 활성화 구현

# 📜작업 내용
## Passive.cs 제작
- 기본적인 패시브 명칭 Enum로 구현
- Luck 패시브(치명타율+드랍률) 때문에 두가지 value값 부여
- 최대 레벨 5로 제작

## PlayerStatController.cs 수정
- 경험치 휙득을 통해 레벨업 시 패시브 누적 증가 구현
ex) 최대 체력 20 증가 / 40 증가 / 60증가
--> 최대 체력 120 / 140 / 160
--> 즉, Default 체력에서 최종 체력이 얼마가 증가했는지에 대한 Description임.
--> 다른 패시브 스탯도 같음.

## InGameUIController.cs 수정
- 레벨업 시 랜덤 패시브 3개를 뽑아 버튼에 띄워주는 로직 구현(ShowRandomPassive)

## Debug.log를 통해 현재 상태 확인
```
        Debug.Log($"[패시브 업그레이드] {data.itemName} Lv.{currentLevel} 달성! " +
                  $"(공격력 배율: {DamageMultiplier} / 방어력: {Defense} / 최대체력: {MaxHp})");
```
위 코드를 통해 Console 창에서 현재 Player 스탯 확인 가능

# 📷관련 영상

https://github.com/user-attachments/assets/a3fa2b5b-45d1-4cc3-b73b-80c96c99e5e1

# 📷 관련 사진
- 스탯 업그레이드 관련 Console창
<img width="931" height="103" alt="스크린샷 2026-02-23 040407" src="https://github.com/user-attachments/assets/5c13ca84-dc38-4947-9c74-b8bfb49a30a6" />
<img width="946" height="96" alt="스크린샷 2026-02-23 040415" src="https://github.com/user-attachments/assets/8af7e578-08e1-4ce8-9471-5f6dafbdac65" />
<img width="960" height="87" alt="스크린샷 2026-02-23 040423" src="https://github.com/user-attachments/assets/d0429735-9495-45ca-8110-0cca79392226" />

# 참고 사항
- 제미나이 이것저것 굴려보다가 제미나이가 999+ 오류 뜨는거 하도 고치라 해서 고쳐놨어요. 
```
        PlayerStatController?.SetUp();
        PlayerMoveController?.SetUp();
        PlayerItemController?.SetUp();
        PlayerAnimationController?.SetUp();
        PlayerSoundController?.SetUp();
```
대략 이런 느낌으로 바꾸었다고 보면 됩니다.
