### PR TITLE
Chore: 진행사항 병합

### DIFF
--- a/Assets/01.Scenes/InGame.unity
+++ b/Assets/01.Scenes/InGame.unity
@@ -1029,6 +1029,50 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 3776920315277696848, guid: de521247ea7cb174e93f04afcdda5f29, type: 3}
   m_PrefabInstance: {fileID: 28435581}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &61686557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 61686559}
+  - component: {fileID: 61686558}
+  m_Layer: 0
+  m_Name: ExpObjectSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &61686558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 61686557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f0268b1556bccd4291ff9e8a657d1ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ExpObjectSpawner
+--- !u!4 &61686559
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 61686557}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &66811873
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4086,7 +4130,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5713951251592491643, guid: 09cc9c576df8b0949a940a1995064870, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.67
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5713951251592491643, guid: 09cc9c576df8b0949a940a1995064870, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4449,6 +4493,51 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47e18aa40702fc947bc11897c42ad8fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ItenSlot
+--- !u!1 &457122006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 457122008}
+  - component: {fileID: 457122007}
+  m_Layer: 0
+  m_Name: ScrapSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &457122007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457122006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e02045d934fc714f867763dbba182a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ScrapSpawner
+  _mapCollider: {fileID: 363870201}
+--- !u!4 &457122008
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457122006}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &459701574
 GameObject:
   m_ObjectHideFlags: 0
@@ -7733,6 +7822,50 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
   m_PrefabInstance: {fileID: 1623076020}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &973181668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 973181670}
+  - component: {fileID: 973181669}
+  m_Layer: 0
+  m_Name: TurretProjectileSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &973181669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973181668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed9cfa3c25bf9a04991eef4b61faacf2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::TurretProjectileSpawner
+--- !u!4 &973181670
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973181668}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.7605, y: 1.39517, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &973325257 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
@@ -10369,6 +10502,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
   m_PrefabInstance: {fileID: 1035851163}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1261736190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390765961493882094, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 822807113821601694, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
+      propertyPath: m_Name
+      value: agit
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 180799490d6ee8b4c9f37b2456751ef9, type: 3}
 --- !u!4 &1287521865 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
@@ -11324,12 +11514,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1832774410}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1373398689}
+    - targetCorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1373398690}
   m_SourcePrefab: {fileID: 100100000, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+--- !u!4 &1373398687 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2786458683079629028, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
+  m_PrefabInstance: {fileID: 1373398686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1373398688 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1648057168967098522, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
@@ -11350,12 +11551,23 @@ MonoBehaviour:
   _tileLayer:
     serializedVersion: 2
     m_Bits: 524288
-  _turrets:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  _turretSelectUI: {fileID: 0}
+  _testTurretDatas:
+  - {fileID: 11400000, guid: 5dc4861079cc6c344914953d7abedd75, type: 2}
+--- !u!114 &1373398690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1373398688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07d0006f0bf429d4f8069afc8f8723a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerLevelControl
+  currentLevel: 1
+  currentXP: 0
+  requiredXP: 0
 --- !u!1001 &1387122544
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12105,187 +12317,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
---- !u!1 &1497558704
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1497558706}
-  - component: {fileID: 1497558705}
-  - component: {fileID: 1497558707}
-  - component: {fileID: 1497558709}
-  - component: {fileID: 1497558708}
-  m_Layer: 0
-  m_Name: Agit
-  m_TagString: Agit
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1497558705
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497558704}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 1
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 21300000, guid: 034af9c1433e348408e370b62e5e85f7, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_SpriteSortPoint: 0
---- !u!4 &1497558706
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497558704}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &1497558707
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497558704}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 4.0507812, y: 3.7695312}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 4.0507812, y: 3.7695312}
-  m_EdgeRadius: 0
---- !u!50 &1497558708
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497558704}
-  m_BodyType: 2
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!114 &1497558709
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497558704}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9017000e5690ecd4cb7cf527aa215577, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::Agit
-  maxHP: 100
-  cameraMoveDuration: 0.5
 --- !u!4 &1509935505 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
@@ -12965,6 +12996,7 @@ MonoBehaviour:
   - {fileID: 1625839965}
   - {fileID: 1840075398}
   _damageTextSpawner: {fileID: 78771459}
+  allPassives: []
   _testEnemies:
   - {fileID: 480067398}
   - {fileID: 1189034493}
@@ -14691,6 +14723,68 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
+--- !u!1001 &1832774409
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1373398687}
+    m_Modifications:
+    - target: {fileID: 2434694142653457009, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_Name
+      value: AutoRifle
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+--- !u!4 &1832774410 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8099240881842937928, guid: 77494ce3c926e7843a7fd0514ee798f3, type: 3}
+  m_PrefabInstance: {fileID: 1832774409}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1835061854
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -30822,14 +30916,17 @@ SceneRoots:
   - {fileID: 1337033341}
   - {fileID: 1638335296}
   - {fileID: 1758264549}
-  - {fileID: 1497558706}
   - {fileID: 100819378}
   - {fileID: 363870203}
-  - {fileID: 296131733}
   - {fileID: 480067397}
   - {fileID: 1189034492}
   - {fileID: 1841578104}
   - {fileID: 1373398686}
   - {fileID: 1087342534}
+  - {fileID: 296131733}
   - {fileID: 489216318}
   - {fileID: 78771463}
+  - {fileID: 1261736190}
+  - {fileID: 973181670}
+  - {fileID: 457122008}
+  - {fileID: 61686559}

--- a/Assets/01.Scenes/Title.unity
+++ b/Assets/01.Scenes/Title.unity
@@ -472,6 +472,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4fcf708fc4aa3664face8c46d0d33dc0, type: 2}
   _turretDatas:
   - {fileID: 11400000, guid: 43b73e018ce3c674fa079794de689944, type: 2}
+  - {fileID: 11400000, guid: 5dc4861079cc6c344914953d7abedd75, type: 2}
 --- !u!4 &849497057
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/03.Data/Weapon/AutoRifleBaseStat.asset
+++ b/Assets/03.Data/Weapon/AutoRifleBaseStat.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 8740604490144623316, guid: fb8d6eb891538344fb197629efe1b660, type: 3}
   level: 1
   type: 1
-  atk: 20
+  damage: 10
   critRate: 20
   critMultiplier: 1.4
   effectRate: 10

--- a/Assets/04.Scripts/Agit/Agit.cs
+++ b/Assets/04.Scripts/Agit/Agit.cs
@@ -35,7 +35,7 @@ public class Agit : MonoBehaviour, IDamageable
         isDestroyed = true;
 
         // 카메라 아지트로 이동
-        yield return StartCoroutine(MoveCameraToAgit());
+        //yield return StartCoroutine(MoveCameraToAgit());
 
         // 아지트 파괴 효과
         yield return new WaitForSeconds(1f);

--- a/Assets/04.Scripts/Enemy/Enemy.cs
+++ b/Assets/04.Scripts/Enemy/Enemy.cs
@@ -92,7 +92,6 @@ public class Enemy : MonoBehaviour, IDamageable
         }
     }
 
-    // NOTE: 적과 닿아있으면 지속적으로 데미지 입히기
     private void OnCollisionStay2D(Collision2D collision)
     {
         if(!_isLive)
@@ -111,6 +110,7 @@ public class Enemy : MonoBehaviour, IDamageable
     public void TakeDamage(int damage)
     {
         _currentHp -= damage;
+        InGameManager.Instance.InGameUIController.ShowDamageText(transform.position, damage);
         if (_currentHp <= 0 && _isLive)
         {
             Die();

--- a/Assets/04.Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/04.Scripts/Enemy/EnemySpawner.cs
@@ -73,6 +73,7 @@ public class EnemySpawner : SingletonBehaviour<EnemySpawner>
         }
         GameObject enemy = _enemyPools[enemyType].Get();
         enemy.transform.position = position;
+        InGameManager.Instance.InGameUIController.AddTracedEnemyInMinimap(enemy.transform);
 
         Enemy enemyComponent = enemy.GetComponent<Enemy>();
         enemyComponent.Initialize(_agitRigidbody);
@@ -89,6 +90,7 @@ public class EnemySpawner : SingletonBehaviour<EnemySpawner>
         {
             Destroy(enemy);
         }
+        InGameManager.Instance.InGameUIController.RemoveTracedEnemyInMinimap(enemy.transform);
     }
 
 

--- a/Assets/04.Scripts/Item_Grounded/ExpObject.cs
+++ b/Assets/04.Scripts/Item_Grounded/ExpObject.cs
@@ -7,8 +7,11 @@ public class ExpObject : ItemGroundedBase
 
     protected override void OnCollectedByPlayer(Collider2D playerColl)
     {
-        // TODO: 플레이어에게 Exp 추가 로직
-        Debug.Log($"Exp 획득: {_expAmount}");
+        if (playerColl.TryGetComponent<PlayerLevelControl>(out PlayerLevelControl playerLevelControl))
+        {
+            playerLevelControl.AddXP(_expAmount);
+            ReturnToPool();
+        }
     }
 
     protected override void ReturnToPool()

--- a/Assets/04.Scripts/Item_Grounded/ItemCollector.cs
+++ b/Assets/04.Scripts/Item_Grounded/ItemCollector.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class ItemCollector : MonoBehaviour
 {
-    private float _collectRadius = 1f;
+    private float _collectRadius = 0.8f;
     private CircleCollider2D _collider;
 
     private void Start()

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -15,19 +15,10 @@ public class PlayerLevelControl : MonoBehaviour
         UpdateRequiredXP();
     }
 
-#if UNITY_EDITOR
-    private void Update()
-    {
-        //if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
-        //if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
-        //if (Input.GetKeyDown(KeyCode.E)) AddXP(4);
-    }
-#endif
-
     public void AddXP(int amount)
     {
         currentXP += amount;
-        PlayerManager.Instance.PlayerStatController.CurrentExp = (int)currentXP;
+        PlayerManager.Instance.PlayerStatController.CurrentExp = currentXP;
         InGameManager.Instance.InGameUIController.UpdateExpBar();
         Debug.Log($"경험치 {amount} 휙득 (현재: {currentXP} / {requiredXP})");
 

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -5,8 +5,8 @@ public class PlayerLevelControl : MonoBehaviour
 {
     [Header("Player Status")]
     [SerializeField] public int currentLevel = 1;
-    [SerializeField] public float currentXP = 0;
-    public float requiredXP = 0;
+    [SerializeField] public int currentXP = 0;
+    public int requiredXP = 0;
 
     public event Action<int> OnLevelUp;
 
@@ -18,15 +18,17 @@ public class PlayerLevelControl : MonoBehaviour
 #if UNITY_EDITOR
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
-        if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
-        if (Input.GetKeyDown(KeyCode.E)) AddXP(4);
+        //if (Input.GetKeyDown(KeyCode.Q)) AddXP(1);
+        //if (Input.GetKeyDown(KeyCode.W)) AddXP(2);
+        //if (Input.GetKeyDown(KeyCode.E)) AddXP(4);
     }
 #endif
 
-    public void AddXP(float amount)
+    public void AddXP(int amount)
     {
         currentXP += amount;
+        PlayerManager.Instance.PlayerStatController.CurrentExp = (int)currentXP;
+        InGameManager.Instance.InGameUIController.UpdateExpBar();
         Debug.Log($"경험치 {amount} 휙득 (현재: {currentXP} / {requiredXP})");
 
         while (currentXP >= requiredXP)
@@ -42,6 +44,7 @@ public class PlayerLevelControl : MonoBehaviour
         UpdateRequiredXP();
 
         Debug.Log($"LEVEL UP! 현재 레벨 {currentLevel}");
+        InGameManager.Instance.InGameUIController.OpenLevelupUI(currentLevel);
 
         OnLevelUp?.Invoke(currentLevel);
     }

--- a/Assets/04.Scripts/Player/PlayerLevelControl.cs
+++ b/Assets/04.Scripts/Player/PlayerLevelControl.cs
@@ -35,7 +35,6 @@ public class PlayerLevelControl : MonoBehaviour
         UpdateRequiredXP();
 
         Debug.Log($"LEVEL UP! 현재 레벨 {currentLevel}");
-        InGameManager.Instance.InGameUIController.OpenLevelupUI(currentLevel);
 
         OnLevelUp?.Invoke(currentLevel);
     }

--- a/Assets/04.Scripts/Player/PlayerStatController.cs
+++ b/Assets/04.Scripts/Player/PlayerStatController.cs
@@ -18,7 +18,7 @@ public class PlayerStatController : MonoBehaviour, IDamageable
     public Dictionary<Passive, int> passiveLevels = new Dictionary<Passive, int>();
 
     public int CurrentLevel { get; set; }
-    public int CurrentExp { get; private set; }
+    public int CurrentExp { get; set; }
     public int MaxHp { get; set; }
     public int CurrentHp { get; set; }
     public int Defense { get; set; }

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -94,7 +94,7 @@ public class InGameUIController : MonoBehaviour
     private void Update()
     {
         HandleInput();
-        UpdateExpBar();
+        //UpdateExpBar();
     }
 
     private void HandleInput()


### PR DESCRIPTION
# 📌개요
- develop에 머지한 내용들 Ingame 씬에서 플레이할 수 있도록 통합

# 📜작업 내용
### InGame 씬 수정
- Spawner 오브젝트들 추가(포탑 투사체, 경험치 오브젝트, 고철 오브젝트 오브젝트 풀 관리하는 오브젝트들)
- agit 오브젝트 수정

### PlayerStatController.cs 수정
- PlayerLevelControll에서 플레이어의 경험치를 늘릴 때 PlayerStatController의 CurrentExp값을 바꿔야 했음. 
- CurrentExp의 set 프로퍼티를 private에서 public으로 바꿈.

### InGameUIController.cs 수정
- UpdateExpBar 함수를 Update 에서 호출하지 않고 경험치 오브젝트를 획득할 때마다 호출하도록 변경

### PlayerLevelControll.cs 수정
- 경험치 UI 반영하도록 코드 추가
- 경험치양 변수 타입을 float에서 int로 통합 
- 테스트용으로 만들었던 q/w/e 버튼 누르면 경험치 오르는 함수 삭제

### Enemy 관련 스크립트들 수정
- EnemySpawner에 적이 스폰될 때 미니맵에 위치가 표시되도록 코드 추가
- Enemy에 적이 피격될 때 화면에 데미지 텍스트가 표시되도록 코드 추가

# 📷관련 자료
딱히 없습니다.

# 참고 사항
- InGameUIController.cs 의 레벨업 시에 UI 띄우는 로직이 승운님이 #48 에서 변경하신 코드로 적용되어 있음. 경민님이 이전에 만들어 둔걸 쓰기로 했으니까 한번 확인해봐야 할 듯?