### PR TITLE
Feat : 레벨업 아이템 설명 출력 및 아이템이 없는 버튼 비활성화 기능 구현

### DIFF
--- a/Assets/02.Prefabs/UI/SelectItemBtn1.prefab
+++ b/Assets/02.Prefabs/UI/SelectItemBtn1.prefab
@@ -553,7 +553,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uAC00\uB098\uB2E4\uB77C\uB9C8\uBC14\uC0AC\n\uC544\uC790\uCC28\uCE74\uD0C0\uD30C\uD558\n\uAD6C\uB204\uB450\uB8E8\uBB34\uBD80\uC218\n\uC6B0\uC8FC\uCD94\uCFE0\uD22C\uD478\uD6C4"
+  m_text: "\uAC00\uB098\uB2E4\uB77C\uB9C8\uBC14\uC0AC\uC544\uC790\uCC28\uCE74\uD0C0\uD30C\uD558\uAD6C\uB204\uB450\uB8E8\uBB34\uBD80\uC218\uC6B0\uC8FC\uCD94\uCFE0\uD22C\uD478\uD6C4"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: e786b25321f08db4a8b2542ef4684bf9, type: 2}
   m_sharedMaterial: {fileID: -7449160132103506112, guid: e786b25321f08db4a8b2542ef4684bf9, type: 2}
@@ -597,7 +597,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 0
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}

--- a/Assets/03.Data/Turret/EMPTower.asset
+++ b/Assets/03.Data/Turret/EMPTower.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - 4
   - 4
   _upgradeDescriptions:
-  - 
+  - "\uC801\uC758 \uC774\uB3D9\uC744 \uC7A0\uC2DC \uCC28\uB2E8\uC2DC\uD0B5\uB2C8\uB2E4."
   - 
   - 
   - 

--- a/Assets/03.Data/Turret/PortableBlackHole.asset
+++ b/Assets/03.Data/Turret/PortableBlackHole.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - 5.5
   - 5.5
   _upgradeDescriptions:
-  - 
+  - "\uC544\uC774\uD15C\uC744 \uB04C\uC5B4\uB2F9\uAE41\uB2C8\uB2E4."
   - 
   - 
   - 

--- a/Assets/03.Data/Weapon/AutoRifleBaseStat.asset
+++ b/Assets/03.Data/Weapon/AutoRifleBaseStat.asset
@@ -25,3 +25,9 @@ MonoBehaviour:
   atkRange: 3
   projectileSpeed: 20
   projectileCount: 1
+  _description:
+  - "\uAE30\uBCF8 \uBB34\uAE30"
+  - 1
+  - 2
+  - 3
+  - 4

--- a/Assets/03.Data/Weapon/BigSwordBaseStat.asset
+++ b/Assets/03.Data/Weapon/BigSwordBaseStat.asset
@@ -25,3 +25,9 @@ MonoBehaviour:
   atkRange: 1
   projectileSpeed: 0
   projectileCount: 1
+  _description:
+  - "\uADFC\uAC70\uB9AC\uC758 \uC801\uC744 \uACF5\uACA9\uD558\uB294 \uBB34\uAE30"
+  - 2
+  - 3
+  - 4
+  - 5

--- a/Assets/03.Data/Weapon/RocketLauncherBaseStat.asset
+++ b/Assets/03.Data/Weapon/RocketLauncherBaseStat.asset
@@ -25,3 +25,9 @@ MonoBehaviour:
   atkRange: 4
   projectileSpeed: 10
   projectileCount: 1
+  _description:
+  - "\uC5EC\uB7EC \uC801\uC744 \uAD00\uD1B5\uD558\uB294 \uBB34\uAE30"
+  - 2
+  - 3
+  - 4
+  - 5

--- a/Assets/03.Data/Weapon/ShotgunBaseStat.asset
+++ b/Assets/03.Data/Weapon/ShotgunBaseStat.asset
@@ -25,3 +25,10 @@ MonoBehaviour:
   atkRange: 1
   projectileSpeed: 20
   projectileCount: 10
+  _description:
+  - "\uADFC\uAC70\uB9AC\uC758 \uC801\uC5D0\uAC8C \uB2E4\uB7C9\uC758 \uD53C\uD574\uB97C
+    \uC785\uD788\uB294 \uBB34\uAE30"
+  - 22
+  - 3
+  - 4
+  - 5

--- a/Assets/03.Data/Weapon/SniperBaseStat.asset
+++ b/Assets/03.Data/Weapon/SniperBaseStat.asset
@@ -25,3 +25,9 @@ MonoBehaviour:
   atkRange: 6
   projectileSpeed: 40
   projectileCount: 1
+  _description:
+  - "\uBA3C \uAC70\uB9AC\uC758 \uC801\uC744 \uAD00\uD1B5\uD558\uB294 \uBB34\uAE30"
+  - 
+  - 
+  - 
+  - 

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -438,22 +438,15 @@ public class InGameUIController : MonoBehaviour
         T newItemData = DataTableManager.Instance.GetSelectableItem<T>(_selectedItemName);
         if (EqualityComparer<T>.Default.Equals(newItemData, default(T)))
         {
-            if (_itemSelectBtnDatas.Length > index)
-            {
-                if (_itemSelectBtnDatas[index].ItemNameText != null) _itemSelectBtnDatas[index].ItemNameText.text = "";
-                if (_itemSelectBtnDatas[index].ItemImage != null)
-                {
-                    _itemSelectBtnDatas[index].ItemImage.sprite = null;
-                    _itemSelectBtnDatas[index].ItemImage.color = new Color(1, 1, 1, 0);
-                }
-                if (_itemSelectBtnDatas[index].ItemLevelText != null) _itemSelectBtnDatas[index].ItemLevelText.text = "";
-                if (_itemSelectBtnDatas[index].ItemDescriptionText != null) _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
-            }
-            if (_itemSelectBtns.Length > index && _itemSelectBtns[index] != null) _itemSelectBtns[index].onClick.RemoveAllListeners();
+            _itemSelectBtns[index].gameObject.SetActive(false);
+            _itemSelectBtns[index].onClick.RemoveAllListeners();
             return;
         }
 
+        _itemSelectBtns[index].gameObject.SetActive(true);
+
         _selectedItemName[index] = newItemData.GetName();
+        _itemSelectBtns[index].interactable = true;
 
         if (PlayerManager.Instance == null) return;
         int currentItemLevel = PlayerManager.Instance.PlayerItemController.GetItemLevelInSlot<T>(newItemData);

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -469,7 +469,7 @@ public class InGameUIController : MonoBehaviour
             if (_itemSelectBtnDatas[index].ItemNameText != null) _itemSelectBtnDatas[index].ItemNameText.text = newItemData.GetName();
             if (_itemSelectBtnDatas[index].ItemImage != null) _itemSelectBtnDatas[index].ItemImage.sprite = newItemData.GetIcon();
             if (_itemSelectBtnDatas[index].ItemLevelText != null) _itemSelectBtnDatas[index].ItemLevelText.text = ItemLevel.ToString();
-            if (_itemSelectBtnDatas[index].ItemDescriptionText != null) _itemSelectBtnDatas[index].ItemDescriptionText.text = "";
+            if (_itemSelectBtnDatas[index].ItemDescriptionText != null) _itemSelectBtnDatas[index].ItemDescriptionText.text = newItemData.GetDescription(ItemLevel);
         }
 
         if (_itemSelectBtns.Length > index && _itemSelectBtns[index] != null)

--- a/Assets/04.Scripts/Weapon/ScriptableObjects/WeaponStatData.cs
+++ b/Assets/04.Scripts/Weapon/ScriptableObjects/WeaponStatData.cs
@@ -70,6 +70,10 @@ public class WeaponStatData : ScriptableObject, IItemStatData
     private int projectileCount;
     public int ProjectileCount => projectileCount;
 
+    [Header("아이템 설명")]
+    [SerializeField]
+    private string[] _description;
+
     public string GetName()
     {
         return WeaponName;
@@ -78,5 +82,10 @@ public class WeaponStatData : ScriptableObject, IItemStatData
     public Sprite GetIcon()
     {
         return icon;
+    }
+
+    public string GetDescription(int level)
+    {
+        return _description[level-1];
     }
 }

--- a/Assets/04.Scripts/_Common/IItemStatData.cs
+++ b/Assets/04.Scripts/_Common/IItemStatData.cs
@@ -4,5 +4,6 @@ public interface IItemStatData
 {
     public string GetName();
     public Sprite GetIcon();
+    public string GetDescription(int level);
 }
 

--- a/Assets/04.Scripts/_ScriptableObjects/PassiveStatData.cs
+++ b/Assets/04.Scripts/_ScriptableObjects/PassiveStatData.cs
@@ -77,4 +77,9 @@ public class PassiveStatData : ScriptableObject, IItemStatData
     {
         return _icon;
     }
+
+    public string GetDescription(int level)
+    {
+        throw new System.NotImplementedException();
+    }
 }

--- a/Assets/04.Scripts/_ScriptableObjects/Turret/TurretData.cs
+++ b/Assets/04.Scripts/_ScriptableObjects/Turret/TurretData.cs
@@ -24,7 +24,7 @@ public abstract class TurretData : ScriptableObject, IItemStatData
     {
         return _icon;
     }
-    public string GetUpgradeDescription(int level)
+    public string GetDescription(int level)
     {
         if (level > 0 && level - 1 < _upgradeDescriptions.Length)
         {

--- a/Assets/Resources/Texture/0.mat
+++ b/Assets/Resources/Texture/0.mat
@@ -54,7 +54,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 100.56104
+    - _UnscaledTime: 61.793056
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _RepeatVector: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/Glich_TV.mat
+++ b/Assets/Resources/Texture/Glich_TV.mat
@@ -62,7 +62,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 20.68585
+    - _UnscaledTime: 17.855244
     m_Colors:
     - White: {r: 1, g: 1, b: 1, a: 1}
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/buttonShine.mat
+++ b/Assets/Resources/Texture/buttonShine.mat
@@ -49,7 +49,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 99.92043
+    - _UnscaledTime: 60.17533
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _Color: {r: 0, g: 0, b: 0, a: 1}


### PR DESCRIPTION
# 📌개요
- 레벨업 시 선택할 수 있는 아이템에 대한 설명 텍스트가 출력되는 기능 구현
- 레벨업 시 선택할 수 있는 아이템이 3개 이하일 때, 아이템 버튼이 부분적으로 비활성화되는 기능 구현

# 📜작업 내용
### 설명 텍스트 출력 기능
- 레벨업될 때 출력되는 버튼의 설명 텍스트에 아이템들의 데이터에 들어있는 description값을 대입하도록 구현

### 아이템 버튼 비활성화 기능 
- 레벨업될 때 선택할 수 있는 아이템이 없을 때, 아이템이 없는 버튼을 비활성화 시킴.
- 기존에는 버튼의 아이콘, 이름 텍스트, 레벨 텍스트 등을 초기화하는 작업을 진행했는데, 그럴 필요 없이 비활성화시킴. 이로 인해 코드 줄이 감소함.

# 📷관련 자료
<img width="1024" height="566" alt="스크린샷 2026-03-02 122959" src="https://github.com/user-attachments/assets/586105e0-51e2-4f80-b933-1fe21f8839ea" />
<img width="1018" height="586" alt="스크린샷 2026-03-02 124532" src="https://github.com/user-attachments/assets/80d81ed0-00a2-4c6e-94ae-b435151d5979" />



# 참고 사항
- 무기 아이템은 설명이 없어서 임시로 필드만 만들어놓은 상태임. 따로 추가해야 함.
- 터렛 아이템 중 일부가 설명이 없었음. 수정 부탁드립니다.