### PR TITLE
refactor(#64): 무기가 태그가 아닌 레이어 기반으로 적을 찾도록 수정 완료

### DIFF
--- a/Assets/02.Prefabs/Weapon/Weapons/AutoRifle.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/AutoRifle.prefab
@@ -113,6 +113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23eaf59f55b46944094f18cb6c77b198, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
+  _weaponRangeCollider2D: {fileID: 5700628673114457835}
   level: 0
   damage: 0
   critRate: 0
@@ -135,6 +136,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 0
   _lineRenderer: {fileID: -4189912633782151398}
 --- !u!114 &5751310512860791070
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/AutoRifle.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/AutoRifle.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   _dispersionAngle: 10
   _enemyLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1048576
   _lineRenderer: {fileID: -4189912633782151398}
 --- !u!114 &5751310512860791070
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/BigSword.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/BigSword.prefab
@@ -113,6 +113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23eaf59f55b46944094f18cb6c77b198, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
+  _weaponRangeCollider2D: {fileID: 7681371461706651402}
   level: 0
   damage: 0
   critRate: 0
@@ -135,6 +136,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 0
   _lineRenderer: {fileID: -2916213744026694175}
 --- !u!114 &5660576283154385651
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/BigSword.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/BigSword.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   _dispersionAngle: 10
   _enemyLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1048576
   _lineRenderer: {fileID: -2916213744026694175}
 --- !u!114 &5660576283154385651
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/RocketLauncher.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/RocketLauncher.prefab
@@ -87,6 +87,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
   _lineRenderer: {fileID: -9012976560820378015}
 --- !u!114 &6035414204298828862
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/Shotgun.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/Shotgun.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   _dispersionAngle: 10
   _enemyLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1048576
   _lineRenderer: {fileID: -4613020966027650799}
 --- !u!114 &-5654382924020200263
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/Shotgun.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/Shotgun.prefab
@@ -113,6 +113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23eaf59f55b46944094f18cb6c77b198, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
+  _weaponRangeCollider2D: {fileID: 9168252950991371684}
   level: 0
   damage: 0
   critRate: 0
@@ -135,6 +136,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 0
   _lineRenderer: {fileID: -4613020966027650799}
 --- !u!114 &-5654382924020200263
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/Sniper.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/Sniper.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   _dispersionAngle: 10
   _enemyLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1048576
   _lineRenderer: {fileID: 5778697208193919880}
 --- !u!114 &652187539149569847
 MonoBehaviour:

--- a/Assets/02.Prefabs/Weapon/Weapons/Sniper.prefab
+++ b/Assets/02.Prefabs/Weapon/Weapons/Sniper.prefab
@@ -51,6 +51,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 0
   _lineRenderer: {fileID: 5778697208193919880}
 --- !u!114 &652187539149569847
 MonoBehaviour:
@@ -64,6 +67,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23eaf59f55b46944094f18cb6c77b198, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
+  _weaponRangeCollider2D: {fileID: -2793675266237441266}
   level: 0
   damage: 0
   critRate: 0

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -79,7 +79,10 @@ public class WeaponShootController : MonoBehaviour
 
     private void OnTriggerExit2D(Collider2D collision)
     {
-        if (collision.CompareTag("Enemy")) enemiesInRange.Remove(collision.gameObject);
+        if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
+        {
+            enemiesInRange.Remove(collision.gameObject);
+        }
     }
 
     public void ShootProcedurePerUpdate(float weaponDamage, float atkSpeed, float projectileSpeed)

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -24,6 +24,10 @@ public class WeaponShootController : MonoBehaviour
     [SerializeField]
     private float _dispersionAngle = 10f;
     
+    [Header("공격할 적 레이어")]
+    [SerializeField]
+    private LayerMask _enemyLayer;
+    
     // 공격 방향을 확인하기 위한 임시 코드. 추후 삭제 필요
     #region 임시 추가 코드
     [SerializeField]

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -71,7 +71,10 @@ public class WeaponShootController : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.CompareTag("Enemy")) enemiesInRange.Add(collision.gameObject);
+        if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
+        {
+            enemiesInRange.Add(collision.gameObject);
+        }
     }
 
     private void OnTriggerExit2D(Collider2D collision)

--- a/Assets/Resources/Weapon/로켓 런처.prefab
+++ b/Assets/Resources/Weapon/로켓 런처.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8310104116831955907}
   - component: {fileID: 4188357915843382534}
   - component: {fileID: 1039333528494596075}
+  - component: {fileID: 3561674948437025311}
   - component: {fileID: 6035414204298828862}
   - component: {fileID: 736068464906957172}
   - component: {fileID: 3957966006892038675}
@@ -86,6 +87,120 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
+  _lineRenderer: {fileID: 3561674948437025311}
+--- !u!120 &3561674948437025311
+LineRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7345563338146526642}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!114 &6035414204298828862
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Weapon/샷건.prefab
+++ b/Assets/Resources/Weapon/샷건.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 6287138227824963901}
   - component: {fileID: 2214003800823418775}
   - component: {fileID: 3427295095969404082}
+  - component: {fileID: 2259346446854893307}
   - component: {fileID: -5654382924020200263}
   m_Layer: 0
   m_Name: "\uC0F7\uAC74"
@@ -135,6 +136,120 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
+  _lineRenderer: {fileID: 2259346446854893307}
+--- !u!120 &2259346446854893307
+LineRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8596312975404698146}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!114 &-5654382924020200263
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Weapon/스나이퍼.prefab
+++ b/Assets/Resources/Weapon/스나이퍼.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1316208456127034446}
   - component: {fileID: 5050458718745870877}
+  - component: {fileID: -8766072044185880052}
   - component: {fileID: 652187539149569847}
   - component: {fileID: 8448708637893979310}
   - component: {fileID: 6148898747981676751}
@@ -50,6 +51,120 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
+  _lineRenderer: {fileID: -8766072044185880052}
+--- !u!120 &-8766072044185880052
+LineRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4391006765755288406}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!114 &652187539149569847
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Weapon/자동 소총.prefab
+++ b/Assets/Resources/Weapon/자동 소총.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 4165855992570876612}
   - component: {fileID: 8324327203860504292}
   - component: {fileID: 8544294808717868412}
+  - component: {fileID: 2042200141789805921}
   - component: {fileID: 5751310512860791070}
   m_Layer: 0
   m_Name: "\uC790\uB3D9 \uC18C\uCD1D"
@@ -135,6 +136,120 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
+  _lineRenderer: {fileID: 2042200141789805921}
+--- !u!120 &2042200141789805921
+LineRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2434694142653457009}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!114 &5751310512860791070
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Weapon/진짜 대검.prefab
+++ b/Assets/Resources/Weapon/진짜 대검.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: -7890602142270701890}
   - component: {fileID: 1659737480157701853}
   - component: {fileID: 2403523195023086619}
+  - component: {fileID: -2088409331632169165}
   - component: {fileID: 5660576283154385651}
   m_Layer: 0
   m_Name: "\uC9C4\uC9DC \uB300\uAC80"
@@ -135,6 +136,120 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponShootController
   _dispersionAngle: 10
+  _enemyLayer:
+    serializedVersion: 2
+    m_Bits: 1048576
+  _lineRenderer: {fileID: -2088409331632169165}
+--- !u!120 &-2088409331632169165
+LineRenderer:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9119465782883865832}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!114 &5660576283154385651
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 📌개요
무기 시스템의 적 감지 로직을 기존 Tag 방식에서 LayerMask 방식으로 리팩토링하여 성능을 최적화하고 확장성을 확보함.
또한, 인스펙터에서 누락된 컴포넌트 참조를 복구했음.

## 📜작업 내용
- **LayerMask 기반 적 감지 도입**: `WeaponShootController`에서 `_enemyLayer` 변수를 추가하고, `OnTriggerEnter2D`, `OnTriggerExit2D`에서 비트 연산을 통해 타겟 레이어인지 확인하도록 수정
- **프리팹 설정 업데이트**: `AutoRifle`, `BigSword`, `Shotgun`, `RocketLauncher`, `Sniper` 등 주요 무기 프리팹의 `_enemyLayer`를 적 레이어(20번)로 일괄 설정
  - `Resources`에 있는 실제 게임에 사용될 무기 프리팹들을 현재의 작업물로 덮어씌움
  - 이제 실제 작업물과 동일한 환경에서 작동할 것임
- **컴포넌트 참조 누락 수정**: `WeaponStatController`의 `_weaponRangeCollider2D` 필드가 인스펙터에서 할당되지 않았던 문제 해결 및 프리팹 반영

## 📷시연 자료
시연 자료 따로 없음

## 참고 사항
- 딱히 없음