### PR TITLE
Fix: 무기 버그 수정

### DIFF
--- a/Assets/02.Prefabs/Weapon/Bullets/RocketLauncherBullet.prefab
+++ b/Assets/02.Prefabs/Weapon/Bullets/RocketLauncherBullet.prefab
@@ -302,8 +302,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f102a471d32d44f4e94ef787c512cac2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BulletController
-  _lifeTime: 3
+  _lifeTime: 5
   _deleteAfterAnimation: 0
+  _penetratable: 0
+  _isExplosive: 1
 --- !u!114 &3328102590677456804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -317,3 +319,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GenerateExplosion
   explosionPrefab: {fileID: 5562719415326265950, guid: ffa15aebc95aa46bba2e80abe0ae0967, type: 3}
+  _damageableLayer:
+    serializedVersion: 2
+    m_Bits: 3145728
+  _playerDamageMultiplier: 0.6

--- a/Assets/04.Scripts/Weapon/BulletAnimationController.cs
+++ b/Assets/04.Scripts/Weapon/BulletAnimationController.cs
@@ -58,8 +58,7 @@ public class BulletAnimationController : MonoBehaviour
         if (!TryGetComponent<Collider2D>(out _collider2D)) Debug.LogError($"{nameof(_collider2D)}가 null임");
         if (!TryGetComponent<SpriteRenderer>(out _spriteRenderer)) Debug.LogError($"{nameof(_spriteRenderer)}가 null임");
         if (!TryGetComponent<Animator>(out _animator)) Debug.LogError($"{nameof(_animator)}가 null임");
-        if (_deleteAfterAnimation && _bulletAnimationClip != null)
-        _deleteAfterAnimation = _bulletController.DeleteAfterAnimation;
+        if (_deleteAfterAnimation && _bulletAnimationClip != null && _bulletController != null) _bulletController.SetLifeTime(_bulletAnimationClip.length);
     }
 
     private void OnEnable()

--- a/Assets/04.Scripts/Weapon/BulletAnimationController.cs
+++ b/Assets/04.Scripts/Weapon/BulletAnimationController.cs
@@ -60,7 +60,6 @@ public class BulletAnimationController : MonoBehaviour
         if (!TryGetComponent<Animator>(out _animator)) Debug.LogError($"{nameof(_animator)}가 null임");
         if (_deleteAfterAnimation && _bulletAnimationClip != null)
         _deleteAfterAnimation = _bulletController.DeleteAfterAnimation;
-        _bulletController.SetLifeTime(_bulletAnimationClip.length);
     }
 
     private void OnEnable()

--- a/Assets/04.Scripts/Weapon/BulletController.cs
+++ b/Assets/04.Scripts/Weapon/BulletController.cs
@@ -1,13 +1,7 @@
 using System;
 using System.Collections;
-using System.ComponentModel;
-using Unity.VisualScripting;
-using UnityEditor.Build.Pipeline;
 using UnityEngine;
-using UnityEngine.AI;
 using UnityEngine.Pool;
-using UnityEngine.ResourceManagement.ResourceProviders;
-using UnityEngine.UIElements;
 
 [RequireComponent(typeof(BulletSoundController))]
 [RequireComponent(typeof(AudioSource))]
@@ -22,11 +16,12 @@ public class BulletController : MonoBehaviour
     #region 투사체 스탯
     private float _projectileSpeed;
     private float _projectileDmg;
-    public float ProjectileDmg {get => _projectileDmg;}
+    public float ProjectileDmg { get => _projectileDmg; }
     #endregion
     
     private TrailRenderer _trailRenderer;
-    
+    private Coroutine _deactivateCoroutine;
+
     [SerializeField]
     [Header("총알 수명(초)")]
     private float _lifeTime = 3f;
@@ -38,13 +33,18 @@ public class BulletController : MonoBehaviour
     [Header("총알 관통 여부")]
     [SerializeField]
     private bool _penetratable = false;
-    public bool Penetratable {get => _penetratable; set => _penetratable = value;}
+    public bool Penetratable { get => _penetratable; set => _penetratable = value; }
 
-    public bool DeleteAfterAnimation {get => _deleteAfterAnimation; set => _deleteAfterAnimation = value;}
+    [Header("폭발형 투사체 여부 (직접 데미지 스킵)")]
+    [SerializeField]
+    private bool _isExplosive = false;
+    public bool IsExplosive { get => _isExplosive; set => _isExplosive = value; }
+
+    public bool DeleteAfterAnimation { get => _deleteAfterAnimation; set => _deleteAfterAnimation = value; }
 
     #region 오브젝트 풀링
     private IObjectPool<GameObject> _projectilePool;
-    public IObjectPool<GameObject> ProjectilePool {get => _projectilePool; set => _projectilePool = value;}
+    public IObjectPool<GameObject> ProjectilePool { get => _projectilePool; set => _projectilePool = value; }
     #endregion
     
     #region 참조변수
@@ -75,12 +75,7 @@ public class BulletController : MonoBehaviour
         _collider2D.enabled = true;
         ResetTrailRendererLine();
 
-        StartCoroutine(DeactivateAfterTime());
-    }
-
-    private void OnDisable()
-    {
-        StopAllCoroutines();
+        _deactivateCoroutine = StartCoroutine(DeactivateAfterTime());
     }
 
     private void Update() => transform.Translate(Vector2.right * _projectileSpeed * Time.deltaTime);
@@ -96,7 +91,7 @@ public class BulletController : MonoBehaviour
     
     private void ResetTrailRendererLine()
     {
-        if(_trailRenderer == null) return;
+        if (_trailRenderer == null) return;
         _trailRenderer.Clear();
     }
     
@@ -108,21 +103,27 @@ public class BulletController : MonoBehaviour
     {
         yield return _delayForBulletDisable;
         Release();
+        Debug.Log($"총알 lifetime 만료 lifetime: {_lifeTime}");
     }
     #endregion
     
     private void Release()
     {
         if (gameObject.activeSelf) _projectilePool.Release(gameObject);
+        StopCoroutine(_deactivateCoroutine);
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (other.CompareTag("Enemy") && gameObject.activeSelf)
         {
-            if (other.TryGetComponent<IDamageable>(out var target))
+            // NOTE: 폭발형 투사체는 직접 데미지를 주지 않고 GenerateExplosion에서 범위 데미지를 처리한다
+            if (!_isExplosive)
             {
-                target.TakeDamage(_projectileDmg);
+                if (other.TryGetComponent<IDamageable>(out var target))
+                {
+                    target.TakeDamage(_projectileDmg);
+                }
             }
             OnHit?.Invoke();
             if (!_penetratable) Release();

--- a/Assets/04.Scripts/Weapon/BulletController.cs
+++ b/Assets/04.Scripts/Weapon/BulletController.cs
@@ -77,6 +77,10 @@ public class BulletController : MonoBehaviour
 
         _deactivateCoroutine = StartCoroutine(DeactivateAfterTime());
     }
+    private void OnDisable()
+    {
+        StopCoroutine(_deactivateCoroutine);
+    }
 
     private void Update() => transform.Translate(Vector2.right * _projectileSpeed * Time.deltaTime);
     #endregion
@@ -103,14 +107,12 @@ public class BulletController : MonoBehaviour
     {
         yield return _delayForBulletDisable;
         Release();
-        Debug.Log($"총알 lifetime 만료 lifetime: {_lifeTime}");
     }
     #endregion
     
     private void Release()
     {
         if (gameObject.activeSelf) _projectilePool.Release(gameObject);
-        StopCoroutine(_deactivateCoroutine);
     }
 
     private void OnTriggerEnter2D(Collider2D other)

--- a/Assets/04.Scripts/Weapon/EffectController.cs
+++ b/Assets/04.Scripts/Weapon/EffectController.cs
@@ -1,48 +1,29 @@
-using System;
+/*
+이펙트의 애니메이션 재생과 수명을 관리하는 스크립트.
+애니메이션 재생이 끝나면 자동으로 파괴된다.
+*/
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Pool;
-using UnityEngine.WSA;
 
 [RequireComponent(typeof(AudioSource))]
-[RequireComponent(typeof(Collider2D))]
 [RequireComponent(typeof(Animator))]
 public class EffectController : MonoBehaviour
 {
-    public event Action OnHit;
-
     private Coroutine _releaseCoroutine;
-    private Collider2D _collider;
     private Animator _animator;
 
     [Header("Settings")]
     [SerializeField] private float _defaultLifeTime = 1f;
-    [SerializeField] private bool _isProjectile = false;
-    private bool _alreadyDamaged = false;
-    
-    private int _damage;
+
     private WaitForSeconds _waitForSecondsUntilDelete;
-    private readonly List<Collider2D> _overlapResults = new List<Collider2D>();
-    private ContactFilter2D _contactFilter;
 
     private void Awake()
     {
-        _collider = GetComponent<Collider2D>();
         _animator = GetComponent<Animator>();
-
-        _contactFilter.useTriggers = true;
-        _contactFilter.useLayerMask = false;
     }
 
     private void OnEnable()
     {
-        _collider.enabled = true;
-        _alreadyDamaged = false;
-        
-        OnHit -= DisableColliderOnHit;
-        OnHit += DisableColliderOnHit;
-        
         _releaseCoroutine = StartCoroutine(ReleaseRoutine());
     }
 
@@ -53,23 +34,11 @@ public class EffectController : MonoBehaviour
             StopCoroutine(_releaseCoroutine);
             _releaseCoroutine = null;
         }
-        OnHit -= DisableColliderOnHit;
-    }
-
-    private void DisableColliderOnHit()
-    {
-        _collider.enabled = false;
-    }
-
-    public void Init(int damage)
-    {
-        Debug.Log($"데미지 설정: {damage}");
-        _damage = damage;
     }
 
     private IEnumerator ReleaseRoutine()
     {
-        // 애니메이터가 상태를 완전히 인지할 때까지 한 프레임 대기하기 위해 사용
+        // NOTE: 애니메이터가 상태를 완전히 인지할 때까지 한 프레임 대기
         yield return null;
         if (_waitForSecondsUntilDelete == null)
         {
@@ -79,46 +48,5 @@ public class EffectController : MonoBehaviour
         }
         yield return _waitForSecondsUntilDelete;
         Destroy(gameObject);
-    }
-
-    private void OnTriggerEnter2D(Collider2D other)
-    {
-        ApplyAreaDamageFromCollider();
-        
-        if (_isProjectile) Destroy(gameObject);
-    }
-    
-    private void ApplyAreaDamageFromCollider()
-    {
-        if (_alreadyDamaged) return;
-        
-        _overlapResults.Clear();
-        
-        int hitCount = _collider.Overlap(_contactFilter, _overlapResults);
-        
-        if (hitCount > 0)
-        {
-            foreach (var hit in _overlapResults)
-            {
-                if (hit.CompareTag("Enemy"))
-                {
-                    if (hit.TryGetComponent<IDamageable>(out var target))
-                    {
-                        Debug.Log($"적이 공격에 휘말림, damage: {_damage}");
-                        target.TakeDamage(_damage);
-                    }
-                }
-                if (hit.CompareTag("Player"))
-                {
-                    if (hit.TryGetComponent<PlayerStatController>(out var player))
-                    {
-                        int reducedDamage = (int)(_damage * 0.6);
-                        Debug.Log($"플레이어가 폭발에 휘말림, damage: {reducedDamage}");
-                        player.TakeDamage(reducedDamage);
-                    }
-                }
-            }
-            OnHit?.Invoke();
-        }
     }
 }

--- a/Assets/04.Scripts/Weapon/GenerateExplosion.cs
+++ b/Assets/04.Scripts/Weapon/GenerateExplosion.cs
@@ -45,7 +45,6 @@ public class GenerateExplosion : MonoBehaviour
             // NOTE: CircleCollider2D.radius는 로컬 스페이스 값이므로 프리팹의 Scale을 반영해야 한다
             float scale = Mathf.Max(explosionPrefab.transform.localScale.x, explosionPrefab.transform.localScale.y);
             _explosionRadius = collider.radius * scale;
-            Debug.Log($"폭발 범위 캐싱: radius={collider.radius}, scale={scale}, 최종={_explosionRadius}");
         }
         else
         {

--- a/Assets/04.Scripts/Weapon/GenerateExplosion.cs
+++ b/Assets/04.Scripts/Weapon/GenerateExplosion.cs
@@ -1,38 +1,105 @@
-using Unity.VisualScripting;
+/*
+투사체 충돌 시 폭발 이펙트를 생성하고 범위 데미지를 적용하는 스크립트.
+폭발 범위는 explosionPrefab에 부착된 CircleCollider2D의 radius를 기준으로 한다.
+*/
 using UnityEngine;
-using UnityEngine.Pool;
 
 public class GenerateExplosion : MonoBehaviour
 {
-    private Collider2D _bulletCollider;
     private BulletController _bulletController;
+
     [SerializeField]
     private GameObject explosionPrefab;
-    private IObjectPool<GameObject> _projectilePool;
-    public IObjectPool<GameObject> ProjectilePool {get => _projectilePool;}
+
+    [Header("폭발 피해를 받는 레이어")]
+    [SerializeField]
+    private LayerMask _damageableLayer;
+
+    [Header("플레이어 폭발 데미지 배율")]
+    [SerializeField]
+    private float _playerDamageMultiplier = 0.6f;
+
+    private float _explosionRadius;
 
     private void Awake()
     {
-        if (!gameObject.TryGetComponent<Collider2D>(out _bulletCollider)) Debug.LogError("총알에 Collider2D 없음");
-        if (!gameObject.TryGetComponent<BulletController>(out _bulletController)) Debug.LogError("총알에 BulletController 컴포넌트 없음");
-        if (_bulletCollider != null) _projectilePool = _bulletController.ProjectilePool;
+        if (!gameObject.TryGetComponent<BulletController>(out _bulletController))
+        {
+            Debug.LogError("총알에 BulletController 컴포넌트 없음");
+            return;
+        }
+
+        CacheExplosionRadius();
+    }
+
+    private void CacheExplosionRadius()
+    {
+        if (explosionPrefab == null)
+        {
+            Debug.LogError("explosionPrefab이 할당되지 않음");
+            return;
+        }
+
+        if (explosionPrefab.TryGetComponent<CircleCollider2D>(out var collider))
+        {
+            // NOTE: CircleCollider2D.radius는 로컬 스페이스 값이므로 프리팹의 Scale을 반영해야 한다
+            float scale = Mathf.Max(explosionPrefab.transform.localScale.x, explosionPrefab.transform.localScale.y);
+            _explosionRadius = collider.radius * scale;
+            Debug.Log($"폭발 범위 캐싱: radius={collider.radius}, scale={scale}, 최종={_explosionRadius}");
+        }
+        else
+        {
+            Debug.LogError("explosionPrefab에 CircleCollider2D가 없음");
+        }
     }
 
     private void OnEnable()
     {
-        if (_bulletController == null) Debug.LogWarning("bulletController가 null임");
-        _bulletController.OnHit += GenerateExplosionOnBulletPosition;
+        if (_bulletController == null) return;
+        _bulletController.OnHit += HandleExplosion;
     }
 
     private void OnDisable()
     {
-        _bulletController.OnHit -= GenerateExplosionOnBulletPosition;
+        if (_bulletController == null) return;
+        _bulletController.OnHit -= HandleExplosion;
     }
 
-    private void GenerateExplosionOnBulletPosition()
+    private void HandleExplosion()
     {
-        Vector2 bulletPosision = gameObject.transform.position;
-        GameObject createdExplosion = Instantiate(explosionPrefab, bulletPosision, Quaternion.identity);
-        EffectController effectController = createdExplosion.GetComponent<EffectController>();
+        Vector2 explosionPosition = transform.position;
+        ApplyAreaDamage(explosionPosition, _bulletController.ProjectileDmg);
+        SpawnExplosionEffect(explosionPosition);
+    }
+
+    private void ApplyAreaDamage(Vector2 center, float damage)
+    {
+        Collider2D[] hits = Physics2D.OverlapCircleAll(center, _explosionRadius, _damageableLayer);
+
+        foreach (var hit in hits)
+        {
+            if (hit.CompareTag("Enemy"))
+            {
+                if (hit.TryGetComponent<IDamageable>(out var target))
+                {
+                    target.TakeDamage(damage);
+                    Debug.Log($"적이 폭발에 휘말림, damage: {damage}");
+                }
+            }
+            else if (hit.CompareTag("Player"))
+            {
+                if (hit.TryGetComponent<PlayerStatController>(out var player))
+                {
+                    float reducedDamage = damage * _playerDamageMultiplier;
+                    player.TakeDamage(reducedDamage);
+                    Debug.Log($"플레이어가 폭발에 휘말림, damage: {reducedDamage}");
+                }
+            }
+        }
+    }
+
+    private void SpawnExplosionEffect(Vector2 position)
+    {
+        Instantiate(explosionPrefab, position, Quaternion.identity);
     }
 }

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -24,8 +24,6 @@ public class WeaponShootController : MonoBehaviour
     [SerializeField]
     private float _dispersionAngle = 10f;
 
-    public int EnemyCountInRange;
-
     [Header("공격할 적 레이어")]
     [SerializeField]
     private LayerMask _enemyLayer;
@@ -76,7 +74,6 @@ public class WeaponShootController : MonoBehaviour
         if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
         {
             _enemiesInRange.Add(collision.gameObject);
-            EnemyCountInRange = _enemiesInRange.Count;
         }
     }
 
@@ -85,7 +82,6 @@ public class WeaponShootController : MonoBehaviour
         if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
         {
             _enemiesInRange.Remove(collision.gameObject);
-            EnemyCountInRange = _enemiesInRange.Count;
         }
     }
 

--- a/Assets/04.Scripts/Weapon/WeaponShootController.cs
+++ b/Assets/04.Scripts/Weapon/WeaponShootController.cs
@@ -14,7 +14,7 @@ public class WeaponShootController : MonoBehaviour
     private IObjectPool<GameObject> _projectilePool;
     private GameObject _bulletPrefab;
     private CircleCollider2D _weaponRangeCollider;
-    private List<GameObject> enemiesInRange = new List<GameObject>();
+    private List<GameObject> _enemiesInRange = new List<GameObject>();
     private WeaponStatController _weaponStatController;
     private WeaponEventController _weaponEventController;
 
@@ -23,7 +23,9 @@ public class WeaponShootController : MonoBehaviour
     private float _atkCoolTime, _projectileSpeed = 0f;
     [SerializeField]
     private float _dispersionAngle = 10f;
-    
+
+    public int EnemyCountInRange;
+
     [Header("공격할 적 레이어")]
     [SerializeField]
     private LayerMask _enemyLayer;
@@ -73,7 +75,8 @@ public class WeaponShootController : MonoBehaviour
     {
         if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
         {
-            enemiesInRange.Add(collision.gameObject);
+            _enemiesInRange.Add(collision.gameObject);
+            EnemyCountInRange = _enemiesInRange.Count;
         }
     }
 
@@ -81,7 +84,8 @@ public class WeaponShootController : MonoBehaviour
     {
         if (((1 << collision.gameObject.layer) & _enemyLayer) != 0)
         {
-            enemiesInRange.Remove(collision.gameObject);
+            _enemiesInRange.Remove(collision.gameObject);
+            EnemyCountInRange = _enemiesInRange.Count;
         }
     }
 
@@ -93,7 +97,7 @@ public class WeaponShootController : MonoBehaviour
             return;
         }
         _atkCoolTime += Time.deltaTime;
-        if (enemiesInRange.Count >= 1 && _atkCoolTime >= atkSpeed)
+        if (_enemiesInRange.Count >= 1 && _atkCoolTime >= atkSpeed)
         {
             _atkCoolTime = 0f;
             Shoot(weaponDamage, projectileSpeed);
@@ -120,21 +124,23 @@ public class WeaponShootController : MonoBehaviour
     
     private Vector2 FindClosestTargetVector(Vector2 playerPos)
     {
-        if (enemiesInRange.Count == 0) return Vector2.zero;
+        if (_enemiesInRange.Count == 0) return Vector2.zero;
         
         int smallestIndex = 0;
         float smallestDistance = float.MaxValue;
         
         Vector2 targetPos = Vector2.zero;
-        for (int i = 0; i < enemiesInRange.Count; i++)
+        _enemiesInRange.RemoveAll(enemy => enemy == null);
+        for (int i = 0; i < _enemiesInRange.Count; i++)
         {
-            if (enemiesInRange[i] == null) continue;
-            Vector2 targetCandidatePos = enemiesInRange[i].transform.position;
+            if (_enemiesInRange[i] == null) continue;
+            Vector2 targetCandidatePos = _enemiesInRange[i].transform.position;
             float oneEnemyDistance = GetDirectionVector(playerPos,targetCandidatePos).sqrMagnitude;
             if (smallestDistance > oneEnemyDistance)
             {
                 smallestIndex = i;
                 targetPos = targetCandidatePos;
+                smallestDistance = oneEnemyDistance;
             }
         }
         // 공격 방향을 확인하기 위한 임시 코드. 추후 삭제 필요


### PR DESCRIPTION
# 📌개요
- 무기가 타겟을 제대로 찾지 못하던 버그 수정
- 총알이 너무 빨리 사라지던 버그 수정
- 로켓런처 폭발데미지가 안들어가던 문제 수정 및 코드 리팩토링

# 📜작업 내용
### 무기 타겟 선정 버그 #89 
- WeaponShootController.cs의 `FindClosestTargetVector` 함수에서 for를 통해 적들을 탐색하며 `smallestDistance`값을 갱신하지 않아 항상 타겟이 갱신돼 `_enemiesInRange`의 제일 마지막 요소가 타겟이 되는 거였음.
- smallestDistance 값 갱신하는 코드 추가함.

### 총알이 너무 빨리 사라지던 버그 #84 
- 로그 찍어보니까 자동소총의 몇몇 총알의 라이프타임(수명)이 0.5초로 설정됨.
- BulletAnimationController.cs 의 `Awake` 함수에서 `_bulletController.SetLifeTime(_bulletAnimationClip.length);` 가 항상 실행되고 있었던 것이 문제였음. 
- 근데 BulletController.cs에서 총알 수명 설정하는 것도 `Awake`의 `CashingWaitForSeconds`에서 하고 있어서 초기화 순서에 따라 몇개는 수명이 인스펙터에서 할당된 값으로 초기화되고 몇개는 _bulletAnimationClip.length 값으로 설정 된 듯.
- `_bulletController.SetLifeTime(_bulletAnimationClip.length);` 코드가 아마도 `_deleteAferAnimation`이 `true`일 때 이 코드를 실행시켜야 할 것 같아서 일단 그렇게 수정함.
- 이 부분은 확인하고 나중에 다시 수정해 주세요.

### 로켓런처 문제
- 로켓런처의 폭발 데미지가 적용이 되지 않던 문제가 있었음.
- 폭발 데미지 처리를 EffectController.cs 에서 하고 있었는데, damage값을 받아오는 로직이 없어서 작동을 안하고 있었음.
- 폭발 범위의 데미지를 처리하는 로직을 EffectController.cs가 아니라 GenerateExplosion.cs 에서 `OnHit` 이벤트가 발생했을 때 처리하도록 옮김. 
- 데미지가 이중으로 들어가게 하지 않기 위해(직격 데미지, 폭발 데미지) BulletController.cs에 _isExplosive 필드를 추가함. 로켓런처 투사체는 이 값이 `true`
 

# 📷관련 자료



# 참고 사항
- 위에서도 언급했지만 BulletAnimationController의 `Awake` 함수는 향후 다시 수정이 필요할 듯 합니다. 