### PR TITLE
Fix: 플레이어가 아지트와 벽을 뚫는 버그 수정

### DIFF
--- a/Assets/01.Scenes/InGame.unity
+++ b/Assets/01.Scenes/InGame.unity
@@ -8938,7 +8938,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8592272979165148098, guid: 372bc9bf538ea4d40b53192f0ff0b984, type: 3}
       propertyPath: m_BodyType
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/04.Scripts/Player/PlayerManager.cs
+++ b/Assets/04.Scripts/Player/PlayerManager.cs
@@ -46,7 +46,7 @@ public class PlayerManager : MonoBehaviour
         }
     }
 
-    private void Update()
+    private void FixedUpdate()
     {
         PlayerMoveController.MovePlayer();
     }

--- a/Assets/04.Scripts/Player/PlayerMoveController.cs
+++ b/Assets/04.Scripts/Player/PlayerMoveController.cs
@@ -5,6 +5,7 @@ public class PlayerMoveController : MonoBehaviour
 {
 #region variables
     private SpriteRenderer _spriteRenderer;
+    private Rigidbody2D _rigidBody;
 
     private float _moveSpeed;
     private Vector2 _inputVector;
@@ -56,6 +57,9 @@ public class PlayerMoveController : MonoBehaviour
         _playerManager = PlayerManager.Instance;
         _playerStatController = _playerManager.PlayerStatController;
         _playerEventController = _playerManager.PlayerEventController;
+
+        _rigidBody = GetComponent<Rigidbody2D>();
+        _rigidBody.freezeRotation = true;
     }
     
     private void normalVariableSetup()
@@ -95,18 +99,19 @@ public class PlayerMoveController : MonoBehaviour
 #region 메서드들
     public void MovePlayer()
     {
-
-        _currentPos += InputVector * _playerStatController.MoveSpeed * Time.deltaTime;
+        _currentPos = _rigidBody.position;
+        _currentPos += InputVector * _playerStatController.MoveSpeed * Time.fixedDeltaTime;
 
         bool isMoving = CheckMove();
         if (isMoving == false) return;
-        transform.position = _currentPos;
+
+        _rigidBody.MovePosition(_currentPos);
         UpdatePosition();
     }
     
     private bool CheckMove()
     {
-        if (_lastPos != _currentPos)
+        if (InputVector != _currentPos)
         {
             _playerEventController.CallMove();
             return true;

--- a/Assets/04.Scripts/Player/PlayerMoveController.cs
+++ b/Assets/04.Scripts/Player/PlayerMoveController.cs
@@ -102,6 +102,8 @@ public class PlayerMoveController : MonoBehaviour
         _currentPos = _rigidBody.position;
         _currentPos += InputVector * _playerStatController.MoveSpeed * Time.fixedDeltaTime;
 
+        _rigidBody.linearVelocity = Vector2.zero;
+
         bool isMoving = CheckMove();
         if (isMoving == false) return;
 
@@ -111,7 +113,7 @@ public class PlayerMoveController : MonoBehaviour
     
     private bool CheckMove()
     {
-        if (InputVector != _currentPos)
+        if (InputVector != Vector2.zero)
         {
             _playerEventController.CallMove();
             return true;

--- a/Assets/Resources/Texture/0.mat
+++ b/Assets/Resources/Texture/0.mat
@@ -54,7 +54,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 73.7107
+    - _UnscaledTime: 88.96911
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _RepeatVector: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/0.mat
+++ b/Assets/Resources/Texture/0.mat
@@ -54,7 +54,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 193.95193
+    - _UnscaledTime: 73.7107
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _RepeatVector: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/Glich_TV.mat
+++ b/Assets/Resources/Texture/Glich_TV.mat
@@ -62,7 +62,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 216.51991
+    - _UnscaledTime: 99.59429
     m_Colors:
     - White: {r: 1, g: 1, b: 1, a: 1}
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/Glich_TV.mat
+++ b/Assets/Resources/Texture/Glich_TV.mat
@@ -62,7 +62,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 18.99399
+    - _UnscaledTime: 216.51991
     m_Colors:
     - White: {r: 1, g: 1, b: 1, a: 1}
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/Texture/buttonShine.mat
+++ b/Assets/Resources/Texture/buttonShine.mat
@@ -49,7 +49,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 73.064514
+    - _UnscaledTime: 99.59429
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _Color: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Resources/Texture/buttonShine.mat
+++ b/Assets/Resources/Texture/buttonShine.mat
@@ -49,7 +49,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 193.19115
+    - _UnscaledTime: 73.064514
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _Color: {r: 0, g: 0, b: 0, a: 1}


### PR DESCRIPTION
# 📌개요
- Resolves #81 
- 플레이어가 아지트와 벽을 뚫는 버그 픽스

# 📜작업 내용
- Rigidbody 변수 추가
Rigidbody를 통해 Collider 충돌 계

- Time.DeltaTime --> Time.fixedDeltaTime 변경
고정된 주기의 움직임으로 플레이어의 이동속도 일관화.
또한 PlayerManager.cs에서 private void Update() --> pirvate void FixedUpdtae()로 변경

- InGame Scene에서 Player의 Rigidbodyt가 Kinematic으로 설정되어 있음.
Player의 프리팹은 Dynamic으로 되어있지만, InGame Scene에서는 Kinematic으로 되어있어 벽과 아지트를 통과.

# 📷관련 영상

https://github.com/user-attachments/assets/194d8416-94ed-486e-9b41-4e1a04330cac