### PR TITLE
Feat : 터렛 HP UI 생성 기능 구현

### DIFF
--- a/Assets/01.Scenes/InGame.unity
+++ b/Assets/01.Scenes/InGame.unity
@@ -468,6 +468,7 @@ GameObject:
   - component: {fileID: 78771461}
   - component: {fileID: 78771460}
   - component: {fileID: 78771459}
+  - component: {fileID: 78771464}
   m_Layer: 5
   m_Name: WorldCanvas
   m_TagString: Untagged
@@ -569,7 +570,7 @@ RectTransform:
   m_Children:
   - {fileID: 1925085228}
   - {fileID: 792296312}
-  - {fileID: 1981121734}
+  - {fileID: 7268957084717379686}
   - {fileID: 1505627921}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -578,6 +579,22 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -0.6}
   m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &78771464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 78771458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b72a04508dc6294e8670bb03bb3a910, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _hpUIPrefab: {fileID: 702640489795312339, guid: 98875cdc4ec59d845a066db700707fba, type: 3}
+  _initSize: 10
+  _maxSize: 50
+  _spawnParent: {fileID: 78771463}
 --- !u!1 &100819376
 GameObject:
   m_ObjectHideFlags: 0
@@ -7252,81 +7269,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 661427612}
   m_CullTransparentMesh: 1
---- !u!1 &665471047
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 665471048}
-  - component: {fileID: 665471050}
-  - component: {fileID: 665471049}
-  m_Layer: 5
-  m_Name: 'AnimationFill '
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &665471048
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 665471047}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1981121734}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &665471049
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 665471047}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
-  m_Color: {r: 0.745283, g: 0.745283, b: 0.745283, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
-  m_Type: 3
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 0
-  m_FillAmount: 0.839
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &665471050
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 665471047}
-  m_CullTransparentMesh: 1
 --- !u!1001 &673213012
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7664,7 +7606,7 @@ MonoBehaviour:
   _blendInTime: 1
   _animSpeed: 1
   _UIOwner: {fileID: 0}
-  _customPosition: {x: 0, y: 0, z: 0}
+  _customPosition: {x: -0.05, y: 541.51, z: 90}
   _isFocus: 0
 --- !u!4 &812005200 stripped
 Transform:
@@ -7748,81 +7690,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
---- !u!1 &930969430
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 930969431}
-  - component: {fileID: 930969433}
-  - component: {fileID: 930969432}
-  m_Layer: 5
-  m_Name: Fill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &930969431
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 930969430}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1981121734}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &930969432
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 930969430}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
-  m_Color: {r: 0.9056604, g: 0.3972944, b: 0.3972944, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
-  m_Type: 3
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 0
-  m_FillAmount: 0.776
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &930969433
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 930969430}
-  m_CullTransparentMesh: 1
 --- !u!4 &949994548 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
@@ -10641,103 +10508,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5713951251592491643, guid: 09cc9c576df8b0949a940a1995064870, type: 3}
   m_PrefabInstance: {fileID: 1510418981}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1981121733
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1981121734}
-  - component: {fileID: 1981121736}
-  - component: {fileID: 1981121735}
-  - component: {fileID: 1981121737}
-  m_Layer: 5
-  m_Name: PlayerHPUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1981121734
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1981121733}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 90}
-  m_LocalScale: {x: 0.01, y: 0.008818342, z: 0.009259259}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 665471048}
-  - {fileID: 930969431}
-  m_Father: {fileID: 78771463}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -2.87}
-  m_SizeDelta: {x: 100, y: 10}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1981121735
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1981121733}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.03875816, b: 0, a: 0.28235295}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1981121736
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1981121733}
-  m_CullTransparentMesh: 1
---- !u!114 &1981121737
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1981121733}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 89fe6af59d18b504e97a97b853772d0c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  _hpBar: {fileID: 930969432}
-  _hpAnimBar: {fileID: 665471049}
-  _blendInTime: 1
-  _animSpeed: 1
-  _UIOwner: {fileID: 1373398688}
-  _customPosition: {x: 0, y: -0.5, z: 0}
-  _isFocus: 1
 --- !u!4 &1995769463 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
@@ -19925,6 +19695,25 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2438694301238225116, guid: f31ed4be9a2386b4697e35144a114d1f, type: 3}
   m_PrefabInstance: {fileID: 414950168}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &1062126751606961156
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4753193717750270814}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7268957084717379686}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1151185928081040814
 GameObject:
   m_ObjectHideFlags: 0
@@ -19992,6 +19781,14 @@ MonoBehaviour:
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
   m_Version: 2
+--- !u!222 &1938258945852930289
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4772558277751910622}
+  m_CullTransparentMesh: 1
 --- !u!20 &2400019965019055377
 Camera:
   m_ObjectHideFlags: 0
@@ -20086,7 +19883,11 @@ PrefabInstance:
     - target: {fileID: 2856213670529371928, guid: 51abe3c32790ed840818e1721bc9bbf3, type: 3}
       propertyPath: _playerHpUI
       value: 
-      objectReference: {fileID: 1981121737}
+      objectReference: {fileID: 7964626109629127657}
+    - target: {fileID: 2856213670529371928, guid: 51abe3c32790ed840818e1721bc9bbf3, type: 3}
+      propertyPath: _hpUISpawner
+      value: 
+      objectReference: {fileID: 78771464}
     - target: {fileID: 2856213670529371928, guid: 51abe3c32790ed840818e1721bc9bbf3, type: 3}
       propertyPath: _worldCanvas
       value: 
@@ -20274,6 +20075,102 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &3710429136629883925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4753193717750270814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
+  m_Color: {r: 0.745283, g: 0.745283, b: 0.745283, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.839
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4753193717750270814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1062126751606961156}
+  - component: {fileID: 6112404026465079970}
+  - component: {fileID: 3710429136629883925}
+  m_Layer: 5
+  m_Name: 'AnimationFill '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4772558277751910622
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8902933054890020311}
+  - component: {fileID: 1938258945852930289}
+  - component: {fileID: 7930173223056101546}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &5431768234449933354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729460233477904453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.03875816, b: 0, a: 0.28235295}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &5668450579320411580
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20286,6 +20183,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7aa991adc339ccc4982545a920a6285f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CameraStacker
+--- !u!1 &5729460233477904453
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7268957084717379686}
+  - component: {fileID: 8914527633312824043}
+  - component: {fileID: 5431768234449933354}
+  - component: {fileID: 7964626109629127657}
+  m_Layer: 5
+  m_Name: PlayerHPUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &6112404026465079970
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4753193717750270814}
+  m_CullTransparentMesh: 1
+--- !u!224 &7268957084717379686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729460233477904453}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 90}
+  m_LocalScale: {x: 0.01, y: 0.008818342, z: 0.009259259}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1062126751606961156}
+  - {fileID: 8902933054890020311}
+  m_Father: {fileID: 78771463}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -2.87}
+  m_SizeDelta: {x: 100, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7930173223056101546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4772558277751910622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
+  m_Color: {r: 0.9056604, g: 0.3972944, b: 0.3972944, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.776
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7964626109629127657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729460233477904453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89fe6af59d18b504e97a97b853772d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _hpBar: {fileID: 7930173223056101546}
+  _hpAnimBar: {fileID: 3710429136629883925}
+  _blendInTime: 1
+  _animSpeed: 1
+  _UIOwner: {fileID: 1373398688}
+  _customPosition: {x: 0, y: -0.5, z: 0}
+  _isFocus: 1
 --- !u!81 &8431931414891805325
 AudioListener:
   m_ObjectHideFlags: 0
@@ -20340,6 +20334,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::FollowPlayer
   _agitTransform: {fileID: 1261736191}
   _cameraMoveDuration: 0.5
+--- !u!224 &8902933054890020311
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4772558277751910622}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7268957084717379686}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8914527633312824043
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729460233477904453}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/02.Prefabs/UI/HPUI.prefab
+++ b/Assets/02.Prefabs/UI/HPUI.prefab
@@ -1,0 +1,249 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &322269070603039304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4453765384363740993}
+  - component: {fileID: 6675867682155952743}
+  - component: {fileID: 2904475358792372796}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4453765384363740993
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 322269070603039304}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2496088758294704880}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6675867682155952743
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 322269070603039304}
+  m_CullTransparentMesh: 1
+--- !u!114 &2904475358792372796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 322269070603039304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
+  m_Color: {r: 0.9056604, g: 0.3972944, b: 0.3972944, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.776
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &555590871550822856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5259651120298194578}
+  - component: {fileID: 1337843311401848884}
+  - component: {fileID: 8448033616620316291}
+  m_Layer: 5
+  m_Name: 'AnimationFill '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5259651120298194578
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555590871550822856}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2496088758294704880}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1337843311401848884
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555590871550822856}
+  m_CullTransparentMesh: 1
+--- !u!114 &8448033616620316291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555590871550822856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 2100000, guid: 0e9c242a348e7d54f8ed504815283138, type: 2}
+  m_Color: {r: 0.745283, g: 0.745283, b: 0.745283, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7791214535279931073, guid: 1f870d9a73f6f2047b977ff8e50f67a7, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.839
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &702640489795312339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2496088758294704880}
+  - component: {fileID: 4464656927776880765}
+  - component: {fileID: 946567476093687484}
+  - component: {fileID: 2939565550191106431}
+  m_Layer: 5
+  m_Name: HPUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2496088758294704880
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702640489795312339}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 90}
+  m_LocalScale: {x: 0.01, y: 0.008818342, z: 0.009259259}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5259651120298194578}
+  - {fileID: 4453765384363740993}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4464656927776880765
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702640489795312339}
+  m_CullTransparentMesh: 1
+--- !u!114 &946567476093687484
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702640489795312339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.03875816, b: 0, a: 0.28235295}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2939565550191106431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702640489795312339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89fe6af59d18b504e97a97b853772d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _hpBar: {fileID: 2904475358792372796}
+  _hpAnimBar: {fileID: 8448033616620316291}
+  _blendInTime: 1
+  _animSpeed: 1
+  _UIOwner: {fileID: 0}
+  _customPosition: {x: 0, y: -0.5, z: 0}
+  _isFocus: 0

--- a/Assets/02.Prefabs/UI/HPUI.prefab.meta
+++ b/Assets/02.Prefabs/UI/HPUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 98875cdc4ec59d845a066db700707fba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Scripts/Agit/Tile.cs
+++ b/Assets/04.Scripts/Agit/Tile.cs
@@ -23,6 +23,8 @@ public class Tile : MonoBehaviour
         currentTurret.transform.parent = this.transform;
         isPlaceable = false;
 
+        InGameManager.Instance.InGameUIController.CreateTurretHpBar(transform);
+
         return currentTurret.GetComponent<TurretBase>();
     }
 

--- a/Assets/04.Scripts/Turret/TurretBase.cs
+++ b/Assets/04.Scripts/Turret/TurretBase.cs
@@ -29,9 +29,12 @@ public abstract class TurretBase : MonoBehaviour, IDamageable, IItemStatControll
     {
         _currentHp -= damage;
 
+        InGameManager.Instance.InGameUIController.UpdateTurretHpBar(transform.parent, _currentHp, (float)_turretData.MaxHp[_level-1]);
+        
         if (_currentHp <= 0)
         {
             OnDestroyed();
+            InGameManager.Instance.InGameUIController.RemoveTurretHpBar(transform.parent);
         }
     }
 

--- a/Assets/04.Scripts/UI/InGame/HpUI.cs
+++ b/Assets/04.Scripts/UI/InGame/HpUI.cs
@@ -27,11 +27,22 @@ public class HpUI : MonoBehaviour
         _hpBar.fillAmount = FULL_AMOUNT;
         _hpAnimBar.fillAmount = FULL_AMOUNT;
         _waitForBlendInTime = new WaitForSeconds(_blendInTime);
+
     }
     private void Update()
     {
         if (!_isFocus || !_UIOwner) return;
+        FollowOwner();
+    }
+
+    private void FollowOwner()
+    {
         transform.position = _UIOwner.transform.position + _customPosition;
+    }
+
+    public void SetPosition(Vector3 position)
+    {
+        transform.position = position + _customPosition;
     }
 
     public void UpdateHpBar(float currentHp, float maxHp)

--- a/Assets/04.Scripts/UI/InGame/HpUI.cs
+++ b/Assets/04.Scripts/UI/InGame/HpUI.cs
@@ -24,10 +24,16 @@ public class HpUI : MonoBehaviour
     
     private void Awake()
     {
-        _hpBar.fillAmount = FULL_AMOUNT;
-        _hpAnimBar.fillAmount = FULL_AMOUNT;
+/*        _hpBar.fillAmount = FULL_AMOUNT;
+        _hpAnimBar.fillAmount = FULL_AMOUNT;*/
         _waitForBlendInTime = new WaitForSeconds(_blendInTime);
 
+    }
+
+    private void OnEnable()
+    {
+        _hpBar.fillAmount = FULL_AMOUNT;
+        _hpAnimBar.fillAmount = FULL_AMOUNT;
     }
     private void Update()
     {

--- a/Assets/04.Scripts/UI/InGame/HpUISpawner.cs
+++ b/Assets/04.Scripts/UI/InGame/HpUISpawner.cs
@@ -1,0 +1,62 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.Pool;
+
+public class HpUISpawner : MonoBehaviour
+{
+    private IObjectPool<HpUI> _hpUIPool;
+    [SerializeField] private GameObject _hpUIPrefab;
+
+    [SerializeField] private int _initSize = 10;
+    [SerializeField] private int _maxSize = 50;
+
+    [SerializeField] private Transform _spawnParent;
+    private void Awake()
+    {
+        CreatePools();
+    }
+
+    private void CreatePools()
+    {
+        HpUI HpUIObj = _hpUIPrefab.GetComponent<HpUI>();
+        var pool = new ObjectPool<HpUI>(
+            createFunc: () => Instantiate(HpUIObj),
+            actionOnGet: ActivateUi,
+            actionOnRelease: DisableUi,
+            collectionCheck: false,
+            defaultCapacity: _initSize,
+            maxSize: _maxSize);
+        _hpUIPool = pool;
+    }
+
+    private void ActivateUi(HpUI obj)
+    {
+        obj.gameObject.SetActive(true);
+    }
+
+    private void DisableUi(HpUI obj)
+    {
+        obj.gameObject.SetActive(false);
+    }
+
+    public HpUI CreateHpUI(Vector3 position)
+    {
+        if (_hpUIPool == null)
+        {
+            Debug.Log("Hp UI Pools is nothing.");
+            return null;
+        }
+
+        var hpUI = _hpUIPool.Get();
+        if (_spawnParent != null)
+            hpUI.transform.SetParent(_spawnParent, false);
+        hpUI.SetPosition(position);
+        
+        return hpUI;
+    }
+
+    public void RemoveHpUI(HpUI obj)
+    {
+        _hpUIPool.Release(obj);
+    }
+}

--- a/Assets/04.Scripts/UI/InGame/HpUISpawner.cs
+++ b/Assets/04.Scripts/UI/InGame/HpUISpawner.cs
@@ -1,4 +1,3 @@
-using TMPro;
 using UnityEngine;
 using UnityEngine.Pool;
 

--- a/Assets/04.Scripts/UI/InGame/HpUISpawner.cs.meta
+++ b/Assets/04.Scripts/UI/InGame/HpUISpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b72a04508dc6294e8670bb03bb3a910

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -493,13 +493,18 @@ public class InGameUIController : MonoBehaviour
 
     public void RemoveTurretHpBar(Transform transform)
     {
-        _hpUISpawner.RemoveHpUI(_turretHpBars[transform]);
-        _turretHpBars.Remove(transform);
+        if (_turretHpBars.TryGetValue(transform, out HpUI hpUI))
+        {
+            _hpUISpawner.RemoveHpUI(hpUI);
+            _turretHpBars.Remove(transform);
+        }
+        
     }
 
     public void UpdateTurretHpBar(Transform transform, float currentHp, float maxHp)
     {
-        _turretHpBars[transform].UpdateHpBar(currentHp, maxHp);
+        if (_turretHpBars.TryGetValue(transform, out HpUI hpUI))
+            hpUI.UpdateHpBar(currentHp, maxHp);
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -34,11 +34,7 @@ public class InGameUIController : MonoBehaviour
     [SerializeField] private HpUI _playerHpUI;
     [SerializeField] private HpUI _agitHpUI;
 
-    [Header("Hp Bar Animation Value")]
-    [SerializeField] private float _blendInTime;
-    [SerializeField] private float _animSpeed;
-    [SerializeField] private Coroutine _playerHpBarAnimCoroutine;
-    [SerializeField] private Coroutine _agitHpBarAnimCoroutine;
+    private Dictionary<Transform, HpUI> _turretHpBars = new Dictionary<Transform, HpUI>();
 
     private Coroutine _messageTextCoroutine;
 
@@ -60,6 +56,7 @@ public class InGameUIController : MonoBehaviour
     [SerializeField] private string[] _selectedItemName = new string[3];
 
     [SerializeField] private DamageTextSpawner _damageTextSpawner;
+    [SerializeField] private HpUISpawner _hpUISpawner;
 
     [Header("New Passive Data Pool")]
     public List<PassiveItemData> allPassives;
@@ -486,6 +483,23 @@ public class InGameUIController : MonoBehaviour
     {
         _inGameUI?.SetActive(false);
         _worldCanvas?.SetActive(false);
+    }
+
+    public void CreateTurretHpBar(Transform transform)
+    {
+        HpUI hpUI = _hpUISpawner.CreateHpUI(transform.position);
+        _turretHpBars[transform] = hpUI;
+    }
+
+    public void RemoveTurretHpBar(Transform transform)
+    {
+        _hpUISpawner.RemoveHpUI(_turretHpBars[transform]);
+        _turretHpBars.Remove(transform);
+    }
+
+    public void UpdateTurretHpBar(Transform transform, float currentHp, float maxHp)
+    {
+        _turretHpBars[transform].UpdateHpBar(currentHp, maxHp);
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD


### PR DESCRIPTION
# 📌개요
- 터렛의 체력을 표시하는 UI 구현

# 📜작업 내용
- 터렛의 체력을 표시하는 UI를 오브젝트 풀 형태로 관리
- 터렛이 생성될 때, HP UI가 터렛 위치 아래에 생성되도록 구현
- 터렛의 현재 체력을 HP UI에 반영
- 터렛이 제거될 때 Hp UI가 사라지도록 구현

# 📷관련 영상


https://github.com/user-attachments/assets/532f9904-a464-4c49-afd8-99f2d636b641

