### PR TITLE
Fix : Config UI 입력 오류 및 미니맵 애니메이션 오류 해결

### DIFF
--- a/Assets/04.Scripts/Player/PlayerItemController.cs
+++ b/Assets/04.Scripts/Player/PlayerItemController.cs
@@ -3,7 +3,6 @@
 아이템을 바꾸는 메서드나 각종 아이템 업그레이드 기능은 무기 개발이 끝나고 구현하도록 함
 */
 using System.Collections.Generic;
-using System.IO;
 using UnityEngine;
 
 public class PlayerItemController : MonoBehaviour

--- a/Assets/04.Scripts/Turret/TurretPlacer.cs
+++ b/Assets/04.Scripts/Turret/TurretPlacer.cs
@@ -42,24 +42,33 @@ public class TurretPlacer : MonoBehaviour
                 GameObject turretPrefab = Resources.Load<GameObject>($"Turret/{turretName}");
                 if (turretPrefab.TryGetComponent<TurretBase>(out var turretBasecomponent))
                 {
-                    if (CheckScrapAmount(turretBasecomponent.GetCost()))
+                    if (component.CanPlaceTurret())
                     {
-                        TurretBase placedTurret = component.PlaceTurret(turretPrefab);
-                        if (placedTurret != null)
+                        if (CheckScrapAmount(turretBasecomponent.GetCost()))
                         {
-                            int currentLevel = TurretManager.Instance.GetTurretLevel(turretName);
-                            placedTurret.Initialize(currentLevel);
-                            TurretManager.Instance.RegisterPlacedTurret(turretName, placedTurret);
+                            TurretBase placedTurret = component.PlaceTurret(turretPrefab);
+                            if (placedTurret != null)
+                            {
+                                int currentLevel = TurretManager.Instance.GetTurretLevel(turretName);
+                                placedTurret.Initialize(currentLevel);
+                                TurretManager.Instance.RegisterPlacedTurret(turretName, placedTurret);
+                            }
+                            UseScrapPoint(turretBasecomponent.GetCost());
+                            EndPlaceTurret?.Invoke();
+                            return;
                         }
-                        UseScrapPoint(turretBasecomponent.GetCost());
-                        EndPlaceTurret?.Invoke();
-                        return;
+                        else
+                        {
+                            Debug.Log("스크랩 재화가 부족합니다..");
+                            InGameManager.Instance.InGameUIController.PrintMessge("스크랩 재화가 부족합니다.");
+                        }
                     }
                     else
                     {
-                        Debug.Log("스크랩 재화가 부족합니다..");
-                        InGameManager.Instance.InGameUIController.PrintMessge("스크랩 재화가 부족합니다.");
+                        Debug.Log("현재 위치에 이미 터렛이 존재합니다.");
+                        InGameManager.Instance.InGameUIController.PrintMessge("현재 위치에 이미 터렛이 존재합니다.");
                     }
+                    
                 }
             }
         }

--- a/Assets/04.Scripts/UI/Common/ConfigUI.cs
+++ b/Assets/04.Scripts/UI/Common/ConfigUI.cs
@@ -13,10 +13,19 @@ public class ConfigUI : BaseUI
     [SerializeField] private Slider _uiSFXSlider;
     [SerializeField] private Slider _gameSFXSlider;
 
+    [SerializeField] private CanvasGroup _canvasGroup;
+
 
     private readonly float _defaultSoundValueScale = 0.01f;
 
-
+    private void Start()
+    {
+        _canvasGroup.blocksRaycasts = false;
+    }
+    private void OnEnable()
+    {
+        EventSystem.current.sendNavigationEvents = false;
+    }
     private void Update()
     {
         InputHandle();
@@ -24,9 +33,11 @@ public class ConfigUI : BaseUI
 
     private void InputHandle()
     {
+        if (EventSystem.current.sendNavigationEvents == false) return;
+
         if (Input.GetKeyDown(KeyCode.Escape))
         {
-            base.OnClickCloseButton();
+            OnClickCloseButton();
         }
         else if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow))
         {
@@ -38,6 +49,14 @@ public class ConfigUI : BaseUI
         }
     }
 
+    public override void OnClickCloseButton()
+    {
+        _canvasGroup.blocksRaycasts = false;
+        EventSystem.current.sendNavigationEvents = false;
+
+        base.OnClickCloseButton();
+
+    }
     private void SetupSound(bool isUp)
     {
         if (EventSystem.current.currentSelectedGameObject.TryGetComponent<ConfigButton>(out ConfigButton component))
@@ -89,9 +108,14 @@ public class ConfigUI : BaseUI
     public void EndFadeIn()
     {
         EventSystem.current.SetSelectedGameObject(MasterVolumeObj);
+
+        _canvasGroup.blocksRaycasts = true;
+        EventSystem.current.sendNavigationEvents = true;
     }
     public void EndFadeOut()
     {
+        EventSystem.current.sendNavigationEvents = true;
+
         if (UIManager.Instance == null) Debug.Log("UIManager Instance is null.");
         else UIManager.Instance.LoadCurrentBtn();
             Close();

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -101,7 +101,6 @@ public class InGameUIController : MonoBehaviour
         InGameManager.Instance.PlayerGameOverAction += EndGame;
         InGameManager.Instance.PlayerWinAction += PlayerWinEndGame;
 
-        UpdateInventory();
 
     }
 
@@ -511,6 +510,7 @@ public class InGameUIController : MonoBehaviour
             InGameManager.Instance.StartGame();
             _inGameUI.SetActive(true);
         }
+        UpdateInventory();
     }
 
     public void ShowFadeOutAnim()

--- a/Assets/04.Scripts/UI/InGame/Minimap.cs
+++ b/Assets/04.Scripts/UI/InGame/Minimap.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework.Constraints;
+using UnityEngine.UI;
 using UnityEngine;
 using UnityEngine.Pool;
 using System.Collections.Generic;
@@ -36,6 +36,8 @@ public class Minimap : MonoBehaviour
 
     Vector2 _unitScale;
     Vector2 _mapPosition = Vector2.zero;
+
+    [SerializeField] private Image _image;
 
     private void Awake()
     {
@@ -172,5 +174,6 @@ public class Minimap : MonoBehaviour
     public void StopWarningAnim()
     {
         _anim.enabled = false;
+        _image.color = Color.white;
     }
 }

--- a/Assets/04.Scripts/Weapon/RicochetController.cs
+++ b/Assets/04.Scripts/Weapon/RicochetController.cs
@@ -71,7 +71,7 @@ public class RicochetController : MonoBehaviour
         if (closestEnemyTransform == null)
         {
             _bulletController.Penetratable = false;
-            Debug.LogError("주변에 적 없으므로 도탄 중지");
+            //Debug.LogError("주변에 적 없으므로 도탄 중지");
             return;
         }
 

--- a/Assets/Resources/UI/ConfigUI.prefab
+++ b/Assets/Resources/UI/ConfigUI.prefab
@@ -826,6 +826,7 @@ GameObject:
   - component: {fileID: 902795982808041590}
   - component: {fileID: 3292189052601691096}
   - component: {fileID: 4879439167418096662}
+  - component: {fileID: 1105546877495249799}
   m_Layer: 5
   m_Name: ConfigUI
   m_TagString: Untagged
@@ -878,6 +879,7 @@ MonoBehaviour:
   _bgmSlider: {fileID: 8302864194156169726}
   _uiSFXSlider: {fileID: 1424884247188358157}
   _gameSFXSlider: {fileID: 4813950231035262026}
+  _canvasGroup: {fileID: 1105546877495249799}
 --- !u!114 &4879439167418096662
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -923,6 +925,18 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+--- !u!225 &1105546877495249799
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100339725016111950}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &7639946436537489579
 GameObject:
   m_ObjectHideFlags: 0
@@ -1170,6 +1184,34 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 3292189052601691096}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1375,6 +1417,34 @@ PrefabInstance:
     - target: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 3292189052601691096}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1585,6 +1655,34 @@ PrefabInstance:
     - target: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 3292189052601691096}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2163,6 +2261,34 @@ PrefabInstance:
     - target: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 3292189052601691096}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Resources/Weapon/로켓 런처.prefab
+++ b/Assets/Resources/Weapon/로켓 런처.prefab
@@ -103,7 +103,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
   _weaponRangeCollider2D: {fileID: 4188357915843382534}
-  _weaponStat: {fileID: 0}
   _level: 0
   _damage: 0
   _critRate: 0
@@ -137,7 +136,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac1cb591fec1e14fa26613b12761b36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponSoundController
-  _weaponShootSound: {fileID: 8300000, guid: c2f7f4c0d0f4a4cc685cf40e345e94cf, type: 3}
+  _weaponShootClipName: RocketLauncherShootSound
 --- !u!114 &4866292833427450968
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Weapon/스나이퍼.prefab
+++ b/Assets/Resources/Weapon/스나이퍼.prefab
@@ -67,7 +67,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStatController
   _weaponRangeCollider2D: {fileID: -2793675266237441266}
-  _weaponStat: {fileID: 0}
   _level: 0
   _damage: 0
   _critRate: 0
@@ -101,7 +100,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac1cb591fec1e14fa26613b12761b36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::WeaponSoundController
-  _weaponShootSound: {fileID: 8300000, guid: b18db8b09a4de46b1bd0f64534710255, type: 3}
+  _weaponShootClipName: SniperShootSound
 --- !u!114 &5387269975543966741
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# 📌개요
- ConfigUI 입력 오류 해결
- 미니맵 애니메이션 오류 해결
- 핸드 캐논 도탄 시 에디터 상에서 플레이가 중지되는 현상 수정
- 이미 터렛이 설치되어있음에도 터렛이 설치되는 오류 해결
- 특정 무기에서 발생하는 사운드 출력 널 오류 해결
- 게임 시작 시 스타트 아이템이 인벤토리에 보이지 않는 오류 해결 

# 📜작업 내용
### ConfigUI 입력 오류 해결
- ConfigUI를 열 때와 닫을 때 입력이 허용되는 오류를 해결
- 슬라이더를 조작해도 볼륨이 조절되지 않는 오류 해결

### 미니맵 애니메이션 오류 해결
- 아지트가 공격받을 때 미니맵이 애니메이션을 실행한 후, 미니맵 색상이 흰색으로 변경되지 않는 오류 해결

### 핸드 캐논 도탄 시 에디터 상에서 플레이가 중지되는 현상 수정
- 에디터 상에서만 발생하기 때문에 딱히 상관없긴 한데 일단 주석 처리 했음.

### 이미 터렛이 설치되어있음에도 터렛이 설치되는 오류 해결
- 스크립트 구조가 터렛이 존재하는 지점에는 터렛이 설치되지 않으면서 스크랩 코스트를 가져가는 구조로 되어있음.
- 터렛이 존재하는지 확인하는 조건문 추가

### 특정 무기에서 발생하는 사운드 출력 널 오류 해결
- 로켓 런처, 스나이퍼에서 사운드 재생 중 널 오류가 생기는 오류 해결

### 게임 시작 시 스타트 아이템이 인벤토리에 보이지 않는 오류 해결 


# 📷관련 영상
![Project4 - Lobby - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 3f1) _DX12_ 2026-03-22 14-37-24](https://github.com/user-attachments/assets/5189c0e1-535f-4e43-b38e-1cb60240d825)


# 참고 사항
