### PR TITLE
Fix/#121

### DIFF
--- a/Assets/02.Prefabs/UI/Sound Setting Btn.prefab
+++ b/Assets/02.Prefabs/UI/Sound Setting Btn.prefab
@@ -389,9 +389,8 @@ MonoBehaviour:
   _selectedImageAnim: {fileID: 4909811677660581827}
   _btnNameText: {fileID: 2790197061247888166}
   _sliderValueText: {fileID: 6716548540228713046}
-  Slider: {fileID: 7865356960332689391}
+  _slider: {fileID: 7865356960332689391}
   _isFirst: 0
-  _configUIObject: {fileID: 0}
   _btnType: 0
   _OnSelectColor: {r: 1, g: 1, b: 0, a: 1}
   _deSelectColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/04.Scripts/Turret/TurretSelectUI.cs
+++ b/Assets/04.Scripts/Turret/TurretSelectUI.cs
@@ -63,7 +63,7 @@ public class TurretSelectUI : MonoBehaviour
 
     private void Update()
     {
-        if (IsSetting)
+        if (IsSetting && InGameManager.Instance.GameStat == GameStat.Play)
         {
             Vector3 mouseScreenPos = Input.mousePosition;
             mouseScreenPos.z = CAMERA_DISTANCE;

--- a/Assets/04.Scripts/UI/Common/ConfigButton.cs
+++ b/Assets/04.Scripts/UI/Common/ConfigButton.cs
@@ -5,10 +5,10 @@ using UnityEngine.UI;
 
 public enum BtnType
 {
-    BGMSoundBtn,
-    MasterSoundBtn,
-    UISoundBtn,
-    CharSoundBtn,
+    BGMSound,
+    MasterSound,
+    UISFXSound,
+    SFXSound,
 }
 
 
@@ -19,7 +19,10 @@ public class ConfigButton : MonoBehaviour, ISelectHandler, IDeselectHandler, IPo
     [SerializeField] private Animator _selectedImageAnim;
     [SerializeField] private TextMeshProUGUI _btnNameText;
     [SerializeField] private TextMeshProUGUI _sliderValueText;
-    public Slider Slider;
+    [SerializeField] private Slider _slider;
+    [SerializeField] private float _defaultSoundValueScale = 0.01f;
+    public Slider Slider { get { return _slider; } }
+
 
     [SerializeField] private bool _isFirst;
 
@@ -32,15 +35,33 @@ public class ConfigButton : MonoBehaviour, ISelectHandler, IDeselectHandler, IPo
     private static readonly int SHOW_BTN = Animator.StringToHash("showBtn");
     private void Awake()
     {
-        if (Slider != null)
-            Slider.value = 1f;
+        if (_slider != null)
+            _slider.value = 1f;
 
+        SetValueText();
+    }
+
+    public void SetValue(bool isUp)
+    {
+        if (isUp)
+        {
+            _slider.value = Mathf.Min(1f, _slider.value + _defaultSoundValueScale);
+        }
+        else
+        {
+            _slider.value = Mathf.Max(0f, _slider.value - _defaultSoundValueScale);
+        }
+    }
+
+    public void SetVolume()
+    {
+        AudioManager.Instance.SetVolumeMixer(_slider.value, BtnType.ToString());
         SetValueText();
     }
 
     public void SetValueText()
     {
-        _sliderValueText.text = ((int)(Slider.value * 10)).ToString();
+        _sliderValueText.text = ((int)(_slider.value * 10)).ToString();
     }
 
     private void OnEnable()

--- a/Assets/04.Scripts/UI/Common/ConfigUI.cs
+++ b/Assets/04.Scripts/UI/Common/ConfigUI.cs
@@ -7,11 +7,11 @@ public class ConfigUI : BaseUI
 {
     [SerializeField] private GameObject MasterVolumeObj;
 
-    [Header("Sliders")]
-    [SerializeField] private Slider _masterSlider;
-    [SerializeField] private Slider _bgmSlider;
-    [SerializeField] private Slider _uiSFXSlider;
-    [SerializeField] private Slider _gameSFXSlider;
+    [Header("Config Buttons")]
+    [SerializeField] private ConfigButton _masterSoundBtn;
+    [SerializeField] private ConfigButton _bgmSoundBtn;
+    [SerializeField] private ConfigButton _uiSFXSoundBtn;
+    [SerializeField] private ConfigButton _gameSFXSoundBtn;
 
     [SerializeField] private CanvasGroup _canvasGroup;
 
@@ -59,50 +59,29 @@ public class ConfigUI : BaseUI
     }
     private void SetupSound(bool isUp)
     {
+        if (EventSystem.current.currentSelectedGameObject == null) return;
+
         if (EventSystem.current.currentSelectedGameObject.TryGetComponent<ConfigButton>(out ConfigButton component))
         {
             ConfigButton currentBtn = component;
 
-            if (currentBtn.BtnType == BtnType.BGMSoundBtn)
+            if (currentBtn.BtnType == BtnType.BGMSound)
             {
-                if (isUp)
-                    _bgmSlider.value += _defaultSoundValueScale;
-                else
-                    _bgmSlider.value -= _defaultSoundValueScale;
+                _bgmSoundBtn.SetValue(isUp);
             }
-            else if (currentBtn.BtnType == BtnType.MasterSoundBtn)
+            else if (currentBtn.BtnType == BtnType.MasterSound)
             {
-                if (isUp)
-                    _masterSlider.value += _defaultSoundValueScale;
-                else
-                    _masterSlider.value -= _defaultSoundValueScale;
+                _masterSoundBtn.SetValue(isUp);
             }
-            else if (currentBtn.BtnType == BtnType.UISoundBtn)
+            else if (currentBtn.BtnType == BtnType.UISFXSound)
             {
-                if (isUp)
-                    _uiSFXSlider.value += _defaultSoundValueScale;
-                else
-                    _uiSFXSlider.value -= _defaultSoundValueScale;
+                _uiSFXSoundBtn.SetValue(isUp);
             }
-            else if (currentBtn.BtnType == BtnType.CharSoundBtn)
+            else if (currentBtn.BtnType == BtnType.SFXSound)
             {
-                if (isUp)
-                    _gameSFXSlider.value += _defaultSoundValueScale;
-                else
-                    _gameSFXSlider.value -= _defaultSoundValueScale;
+                _gameSFXSoundBtn.SetValue(isUp);
             }
-            SetVolume();
         }  
-    }
-
-
-
-    public void SetVolume()
-    {
-        AudioManager.Instance.SetVolumeMixer(_gameSFXSlider.value, "SFX");
-        AudioManager.Instance.SetVolumeMixer(_masterSlider.value, "Master");
-        AudioManager.Instance.SetVolumeMixer(_bgmSlider.value, "BGM");
-        AudioManager.Instance.SetVolumeMixer(_uiSFXSlider.value, "UISFX");
     }
 
     public void EndFadeIn()

--- a/Assets/04.Scripts/UI/InGame/InGameUIController.cs
+++ b/Assets/04.Scripts/UI/InGame/InGameUIController.cs
@@ -184,6 +184,7 @@ public class InGameUIController : MonoBehaviour
 
     public void OnClickOpenPauseUI()
     {
+        if (_turretSelectUI.IsSetting) Cursor.visible = true;
         InGameManager.Instance.PauseGame();
 
         if (_pauseUI != null) _pauseUI.SetActive(true);
@@ -194,7 +195,8 @@ public class InGameUIController : MonoBehaviour
     public void ClosePauseUI()
     {
         if (_pauseUI != null) _pauseUI.SetActive(false);
-        if (_levelupUI != null && !_levelupUI.activeSelf)
+        if (_turretSelectUI.IsSetting) Cursor.visible = false;
+        if (_levelupUI != null && !_levelupUI.activeSelf && !_turretSelectUI.IsSetting)
             Time.timeScale = 1f;
     }
 

--- a/Assets/08.Audio/audioMixer.mixer
+++ b/Assets/08.Audio/audioMixer.mixer
@@ -69,13 +69,13 @@ AudioMixerController:
   m_UpdateMode: 0
   m_ExposedParameters:
   - guid: b7ede6a9cbb22d94088ff2b4bac99a62
-    name: BGM
+    name: BGMSound
   - guid: 7ce75acd18e286e40a205af1bc90c5ae
-    name: Master
+    name: MasterSound
   - guid: 1d8398154f4d10040b52350d20c03da4
-    name: SFX
+    name: SFXSound
   - guid: 47193c23b5f9db84786028727edd8f3c
-    name: UISFX
+    name: UISFXSound
   m_AudioMixerGroupViews:
   - guids:
     - 77897dec20da0d44cb322efbbd31367e

--- a/Assets/Resources/Texture/0.mat
+++ b/Assets/Resources/Texture/0.mat
@@ -54,7 +54,7 @@ Material:
     - _StencilWriteMask: 255
     - _UIMaskSoftnessX: 1
     - _UIMaskSoftnessY: 1
-    - _UnscaledTime: 95.867546
+    - _UnscaledTime: 68.61032
     m_Colors:
     - _ClipRect: {r: 0, g: 0, b: 0, a: 0}
     - _RepeatVector: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Resources/UI/ConfigUI.prefab
+++ b/Assets/Resources/UI/ConfigUI.prefab
@@ -875,10 +875,10 @@ MonoBehaviour:
   FadeInAsset: {fileID: 11400000, guid: d98a7599cc34b3845a5bbf4aff37dfb2, type: 2}
   FadeOutAsset: {fileID: 11400000, guid: a45c59d6ffe43a94181329001eb6b5dd, type: 2}
   MasterVolumeObj: {fileID: 8644096929972656317}
-  _masterSlider: {fileID: 2640739188419620242}
-  _bgmSlider: {fileID: 8302864194156169726}
-  _uiSFXSlider: {fileID: 1424884247188358157}
-  _gameSFXSlider: {fileID: 4813950231035262026}
+  _masterSoundBtn: {fileID: 7698434965433327942}
+  _bgmSoundBtn: {fileID: 4416392286369269034}
+  _uiSFXSoundBtn: {fileID: 6752491441921689817}
+  _gameSFXSoundBtn: {fileID: 917900508032268446}
   _canvasGroup: {fileID: 1105546877495249799}
 --- !u!114 &4879439167418096662
 MonoBehaviour:
@@ -1195,7 +1195,7 @@ PrefabInstance:
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 3292189052601691096}
+      objectReference: {fileID: 4416392286369269034}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -1206,7 +1206,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ConfigUI, Assembly-CSharp
+      value: ConfigButton, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -1258,6 +1258,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &4416392286369269034 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2545875088212452155, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+  m_PrefabInstance: {fileID: 2170434329106949649}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2335812322688892113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65efa0f0f26736a4eb823632202439cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ConfigButton
 --- !u!114 &8302864194156169726 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -1427,11 +1438,23 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 3292189052601691096}
+      objectReference: {fileID: 917900508032268446}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 917900508032268446}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -1439,11 +1462,23 @@ PrefabInstance:
       value: SetVolume
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SetVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ConfigUI, Assembly-CSharp
+      value: ConfigButton, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: ConfigButton, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1454,6 +1489,17 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 3158226550434532205}
   m_SourcePrefab: {fileID: 100100000, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+--- !u!114 &917900508032268446 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2545875088212452155, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+  m_PrefabInstance: {fileID: 3452512971673213861}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269272006426149221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65efa0f0f26736a4eb823632202439cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ConfigButton
 --- !u!1 &1269272006426149221 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4500387315321035456, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -1492,17 +1538,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
---- !u!114 &4813950231035262026 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
-  m_PrefabInstance: {fileID: 3452512971673213861}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &5089345261000761500 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -1667,7 +1702,7 @@ PrefabInstance:
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 3292189052601691096}
+      objectReference: {fileID: 7698434965433327942}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -1678,7 +1713,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ConfigUI, Assembly-CSharp
+      value: ConfigButton, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -1697,17 +1732,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
   m_PrefabInstance: {fileID: 5296961276091744893}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2640739188419620242 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
-  m_PrefabInstance: {fileID: 5296961276091744893}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &5538596233138568934 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 387201655641783451, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -1719,6 +1743,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+--- !u!114 &7698434965433327942 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2545875088212452155, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+  m_PrefabInstance: {fileID: 5296961276091744893}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8644096929972656317}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65efa0f0f26736a4eb823632202439cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ConfigButton
 --- !u!1 &8644096929972656317 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4500387315321035456, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -2273,7 +2308,7 @@ PrefabInstance:
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 3292189052601691096}
+      objectReference: {fileID: 6752491441921689817}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -2284,7 +2319,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ConfigUI, Assembly-CSharp
+      value: ConfigButton, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -2298,17 +2333,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1609894811933560707}
   m_SourcePrefab: {fileID: 100100000, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
---- !u!114 &1424884247188358157 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7865356960332689391, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
-  m_PrefabInstance: {fileID: 9142703994453421026}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &1704715926025720027 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7586655303765474105, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
@@ -2341,6 +2365,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &6752491441921689817 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2545875088212452155, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}
+  m_PrefabInstance: {fileID: 9142703994453421026}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4653905875823669538}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65efa0f0f26736a4eb823632202439cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ConfigButton
 --- !u!114 &8916833750420576121 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 387201655641783451, guid: 8e672e763967e8d4985a12ec756e5e4a, type: 3}


### PR DESCRIPTION
## 📌개요
- 이슈 #121 참조

## 📜작업 내용
- 터렛 설치 상태에서 일시정지 창을 열었을 때 마우스 포인터가 보이도록 변경
- 터렛 설치 상태 - 일시정지 상태에서 일시정지 창을 닫았을 때 게임 시간이 흐르는 오류 해결
- 터렛 설치 상태에서 일시정지 창을 열었을 때 설치할 포탑 이미지가 마우스를 따라오지 않도록 변경

- 사운드 설정값이 슬라이더 아래에 표시되도록 변경

## 📷시연 자료


## 참고 사항